### PR TITLE
Support for images with tuples channels when saving PNGs

### DIFF
--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -194,8 +194,12 @@ class MibiImage(object):
             self.targets = targets
             self._mass_index = dict(zip(masses, range(length)))
             self._target_index = dict(zip(targets, range(length)))
-        else:
+        elif all(isinstance(c, str) for c in channels):
             self.masses = self.targets = None
+        else:
+            raise ValueError(
+                'Channels must be a list of tuples of (int, str) or a '
+                'list of str')
 
     def __eq__(self, other):
         """Checks for equality between MibiImage instances.

--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -462,5 +462,5 @@ class MibiImage(object):
             im = converter(data[:, :, i])
             png_name = label[1] if isinstance(label, tuple) else label
             with warnings.catch_warnings():
-                warnings.simplefilter('ignore')
+                warnings.simplefilter('ignore', UserWarning)
                 skio.imsave(f'{os.path.join(path, png_name)}.png', im)

--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -459,4 +459,5 @@ class MibiImage(object):
             raise TypeError('Unsupported dtype: %s' % data.dtype.type)
         for i, label in enumerate(self.channels):
             im = converter(data[:, :, i])
-            skio.imsave(f'{os.path.join(path, label)}.png', im)
+            png_name = label[1] if isinstance(label, tuple) else label
+            skio.imsave(f'{os.path.join(path, png_name)}.png', im)

--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -4,6 +4,7 @@ Copyright (C) 2018 Ionpath, Inc.  All rights reserved."""
 
 import datetime
 import os
+import warnings
 
 import numpy as np
 from skimage import io as skio, transform
@@ -460,4 +461,6 @@ class MibiImage(object):
         for i, label in enumerate(self.channels):
             im = converter(data[:, :, i])
             png_name = label[1] if isinstance(label, tuple) else label
-            skio.imsave(f'{os.path.join(path, png_name)}.png', im)
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore')
+                skio.imsave(f'{os.path.join(path, png_name)}.png', im)

--- a/mibidata/tests/test_mibi_image.py
+++ b/mibidata/tests/test_mibi_image.py
@@ -18,6 +18,7 @@ STRING_LABELS = ('1', '2', '3')
 TUPLE_LABELS = (
     ('Mass1', 'Target1'), ('Mass2', 'Target2'), ('Mass3', 'Target3'))
 MASS_LABELS = ('Mass1', 'Mass2', 'Mass3')
+MASS_INTEGERS = (1, 2, 3)
 TARGET_LABELS = ('Target1', 'Target2', 'Target3')
 METADATA = {
     'run': 'Run', 'date': '2017-09-16T15:26:00',
@@ -79,6 +80,20 @@ class TestMibiImage(unittest.TestCase):
         image = mi.MibiImage(TEST_DATA, TUPLE_LABELS)
         image.channels = TUPLE_LABELS
         self.assertEqual(image.masses, MASS_LABELS)
+
+    def test_set_channels_ints(self):
+        image = mi.MibiImage(TEST_DATA, TUPLE_LABELS)
+        with self.assertRaises(ValueError):
+            image.channels = MASS_INTEGERS
+
+    def test_set_channels_invalid_tuple(self):
+        image = mi.MibiImage(TEST_DATA, TUPLE_LABELS)
+        invalid_tuple_1 = [(c, ) for c in STRING_LABELS]
+        invalid_tuple_3 = [(c, 'a', 'b') for c in STRING_LABELS]
+        with self.assertRaises(ValueError):
+            image.channels = invalid_tuple_1
+        with self.assertRaises(ValueError):
+            image.channels = invalid_tuple_3
 
     def test_get_labels(self):
         image = mi.MibiImage(TEST_DATA, STRING_LABELS)

--- a/mibidata/tests/test_mibi_image.py
+++ b/mibidata/tests/test_mibi_image.py
@@ -378,6 +378,16 @@ class TestExportGrayscales(unittest.TestCase):
             np.testing.assert_array_equal(
                 roundtripped, resized.data[:, :, i])
 
+    def test_export_with_tuple_channel_names(self):
+        channels = [(1, 'Channel_1'), (2, 'Channel_2')]
+        data = np.random.randint(0, 255, (10, 10, 2)).astype(np.uint16)
+        im = mi.MibiImage(data, channels)
+        im.export_pngs(self.test_dir)
+        images = [skio.imread(f'{os.path.join(self.test_dir,  label)}.png')
+                  for (_, label) in im.channels]
+        for i, roundtripped in enumerate(images):
+            np.testing.assert_array_equal(
+                roundtripped, im.data[:, :, i])
 
 if __name__ == '__main__':
     unittest.main()

--- a/mibidata/tests/test_tiff.py
+++ b/mibidata/tests/test_tiff.py
@@ -141,7 +141,7 @@ class TestWriteReadTiff(unittest.TestCase):
         with self.assertRaises(ValueError):
             tiff.write(self.filename, image)
         # string rather than tuple channels
-        channels = [c[0] for c in CHANNELS]
+        channels = [c[1] for c in CHANNELS]
         image = mi.MibiImage(DATA, channels, **METADATA)
         with self.assertRaises(ValueError):
             tiff.write(self.filename, image)


### PR DESCRIPTION
Fix for export_pngs when the image channels are a tuple of (mass, label) instead of either mass or label.