### PR TITLE
DPPA-228: mibitracker-client function to download single channel

### DIFF
--- a/mibitracker/request_helpers.py
+++ b/mibitracker/request_helpers.py
@@ -501,7 +501,7 @@ class MibiRequests(object):
         tiff_data = self.download_file(tiff_path)
         return tiff.read(tiff_data)
 
-    def get_single_channel(self, image_id, channel_name):
+    def get_channel_data(self, image_id, channel_name):
         """Gets a single channel from MIBItracker as a 2D numpy array.
 
         Args:

--- a/mibitracker/request_helpers.py
+++ b/mibitracker/request_helpers.py
@@ -517,7 +517,9 @@ class MibiRequests(object):
             raise MibiTrackerError(
                 'Specified channel name is not present in image')
         buf = io.BytesIO()
-        buf.write(requests.get(image_info['overlays'][channel_name]).content)
+        response = requests.get(image_info['overlays'][channel_name])
+        response.raise_for_status()
+        buf.write(response.content)
         buf.seek(0)
         return skio.imread(buf)
 

--- a/mibitracker/request_helpers.py
+++ b/mibitracker/request_helpers.py
@@ -10,6 +10,7 @@ import warnings
 import requests
 from requests.adapters import HTTPAdapter
 from requests.exceptions import HTTPError
+from skimage import io as skio
 from urllib3.util.retry import Retry
 
 from mibidata import tiff
@@ -499,6 +500,26 @@ class MibiRequests(object):
                               'summed_image.tiff'))
         tiff_data = self.download_file(tiff_path)
         return tiff.read(tiff_data)
+
+    def get_single_channel(self, image_id, channel_name):
+        """Gets a single channel from MIBItracker as a 2D numpy array.
+
+        Args:
+            image_id: The integer id of an image.
+            channel_name: The name of the channel to download.
+
+        Returns:
+            A MxN numpy array of the channel data.
+        """
+        image_info = self.get('images/{}/'.format(image_id)).json()
+
+        if not channel_name in image_info['overlays']:
+            raise MibiTrackerError(
+                'Specified channel name is not present in image')
+        buf = io.BytesIO()
+        buf.write(requests.get(image_info['overlays'][channel_name]).content)
+        buf.seek(0)
+        return skio.imread(buf)
 
     def create_imageset(self, image_ids, imageset_name,
                         imageset_description=None):


### PR DESCRIPTION
Similar to `get_mibi_image` from DPPA-209 , a helper function for downloading any single channel such that those that are not SIMS pngs can be downloaded.