### PR TITLE
DPPA-266: mibitracker-client support Python 3.6 and 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='mibitracker-client',
       url='https://github.com/ionpath/mibitracker-client',
       description='Python utilities for IONpath MIBItracker and MIBItiff data',
       license='GNU General Public License v3.0',
-      python_requires='==3.7.*',
+      python_requires='~=3.6',
       install_requires=[
           'matplotlib==2.2.3',
           'numpy==1.16.0',


### PR DESCRIPTION
This changes setup.py so that anything with mibitracker-client as a dependency can use Python 3.6 or 3.7 (or really anything >= 3.6 but not 4.0).