### PR TITLE
Fix mixed up labels in image visualization code.

### DIFF
--- a/MibiImage_Tutorial.ipynb
+++ b/MibiImage_Tutorial.ipynb
@@ -1104,11 +1104,11 @@
     "rgb = image[['Keratin', 'dsDNA', 'CD45']]\n",
     "rgb = np.power(rgb / rgb.max(axis=(0, 1)), 1/2)\n",
     "ax[0, 0].imshow(rgb)\n",
-    "ax[0, 0].set_title('Red: Keratin, Green: CD45, Blue: dsDNA')\n",
+    "ax[0, 0].set_title('Red: Keratin, Green: dsDNA, Blue: CD45')\n",
     "\n",
     "cym = color.rgb2cym(rgb)\n",
     "ax[0, 1].imshow(cym)\n",
-    "ax[0, 1].set_title('Cyan: Keratin, Yellow: CD45, Magenta: dsDNA')\n",
+    "ax[0, 1].set_title('Cyan: Keratin, Yellow: dsDNA, Magenta: CD45')\n",
     "\n",
     "ax[1, 0].imshow(color.composite(image, {'Orange': 'Lamin A/C'}))\n",
     "ax[1, 0].set_title('Orange: Lamin A/C')\n",
@@ -1122,7 +1122,7 @@
     "        'Magenta': 'CD68'\n",
     "    })\n",
     "ax[1, 1].imshow(overlay)\n",
-    "ax[1, 1].set_title('Cyan: CD3, Yellow: CD8\\n'\n",
+    "ax[1, 1].set_title('Cyan: CD4, Yellow: CD8\\n'\n",
     "                'Magenta: CD68, Green: CD3')\n",
     "\n",
     "fig.tight_layout()"
@@ -2905,7 +2905,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/MibiImage_Tutorial.ipynb
+++ b/MibiImage_Tutorial.ipynb
@@ -2877,7 +2877,7 @@
    "outputs": [],
    "source": [
     "new_image.export_pngs('/path/to/folder')\n",
-    "outputs = [png_name for png_name in os.path.listdir('/path/to/folder/') if os.path.splitext(png_name)[-1] == '.png']\n",
+    "outputs = [png_name for png_name in os.listdir('/path/to/folder/') if os.path.splitext(png_name)[-1] == '.png']\n",
     "outputs"
    ]
   },

--- a/MibiImage_Tutorial.ipynb
+++ b/MibiImage_Tutorial.ipynb
@@ -2839,7 +2839,7 @@
     "ax[0].imshow(scaled_image[['CD68', 'Lamin A/C', 'dsDNA']])\n",
     "ax[0].set_title('CD68 - Lamin A/C - dsDNA')\n",
     "ax[1].imshow(scaled_image[['CD31', 'CD8', 'Keratin']])\n",
-    "ax[1].set_title('CD31 - CD45 - Keratin')\n",
+    "ax[1].set_title('CD31 - CD8 - Keratin')\n",
     "\n",
     "ax[0].set_xlim((0, 512))\n",
     "ax[0].set_ylim((1024, 512))"


### PR DESCRIPTION
This pull request fixes the code for labeling of the titles of the plots in the image visualization section of the MibiImage_Tutorial notebook, as commented in issue #33 

I can't reproduce the image with the correct labels because I have no access to the data file.