### PR TITLE
DPPA-283: Enforce order of target names when they share the same mass

### DIFF
--- a/mibidata/panels.py
+++ b/mibidata/panels.py
@@ -62,7 +62,7 @@ def read_csv(path):
 
 def _merge_masses(df):
     conjugates = {}
-    targ_list = []
+    target_list = []
     for conj in df.to_dict(orient='records'):
         mass = conj['Mass']
         target = conj['Target']
@@ -71,7 +71,7 @@ def _merge_masses(df):
         else:
             conjugates[mass] = [target]
     for mass in conjugates:
-        targ_list = conjugates[mass]
-        util.natural_sort(targ_list)
-        conjugates[mass] = ', '.join(targ_list)
+        target_list = conjugates[mass]
+        util.natural_sort(target_list)
+        conjugates[mass] = ', '.join(target_list)
     return pd.DataFrame(list(conjugates.items()), columns=['Mass', 'Target'])

--- a/mibidata/panels.py
+++ b/mibidata/panels.py
@@ -5,6 +5,7 @@ Copyright (C) 2019 Ionpath, Inc.  All rights reserved."""
 import numpy as np
 import pandas as pd
 from pandas.errors import ParserError
+from mibidata import util
 
 
 def read_csv(path):
@@ -61,11 +62,16 @@ def read_csv(path):
 
 def _merge_masses(df):
     conjugates = {}
+    targ_list = []
     for conj in df.to_dict(orient='records'):
         mass = conj['Mass']
         target = conj['Target']
         if conjugates.get(mass):
-            conjugates[mass] = f'{conjugates[mass]}, {target}'
+            conjugates[mass].append(target)
         else:
-            conjugates[mass] = target
+            conjugates[mass] = [target]
+    for mass in conjugates:
+        targ_list = conjugates[mass]
+        util.natural_sort(targ_list)
+        conjugates[mass] = ', '.join(targ_list)
     return pd.DataFrame(list(conjugates.items()), columns=['Mass', 'Target'])

--- a/mibidata/tests/test_panels.py
+++ b/mibidata/tests/test_panels.py
@@ -19,6 +19,10 @@ class TestPanel(unittest.TestCase):
 
         cls.simple_csv = 'Mass,Target\n10,Target1\n20,Target2\n30,Target3\n' + \
                          '20,Target4'
+
+        cls.unique_simple_csv = 'Mass,Target\n10,Target1\n20,Target2\n30,' + \
+        'Target3'
+
         cls.tracker_csv = 'Panel ID,0\nPanel Name,The Panel,\nProject ID,0\n' +\
             'Project Name,The Project\nManufacture Data,2018-04-25\n,' +\
             'Description,It has a panel\n\n' +\
@@ -71,9 +75,34 @@ class TestPanel(unittest.TestCase):
             '002,Target3,C,30,P\n' +\
             '004,Target4,D,20,Ne'
 
+        cls.forwards_merge_csv = 'Mass,Target\n10,Target1\n20,Target2\n' + \
+                         '30,Target3\n10,Target4\n30,Target5\n10,Target6\n' + \
+                         '30,Target7'
+
+        cls.backwards_merge_csv = 'Mass,Target\n30,Target7\n10,Target6\n' + \
+                         '30,Target5\n10,Target4\n30,Target3\n20,Target2\n' + \
+                         '10,Target1'
+
         cls.expected_df = pd.DataFrame(
             {'Mass': [10, 20, 30],
              'Target': ['Target1', 'Target2, Target4', 'Target3']},
+            columns=['Mass', 'Target'])
+
+        cls.unique_expected_df = pd.DataFrame(
+            {'Mass': [10, 20, 30],
+             'Target': ['Target1', 'Target2', 'Target3']},
+            columns=['Mass', 'Target'])
+
+        cls.expected_merged_df = pd.DataFrame(
+            {'Mass': [10, 20, 30],
+             'Target': ['Target1, Target4, Target6', 'Target2', 'Target3,' + \
+             ' Target5, Target7']},
+            columns=['Mass', 'Target'])
+
+        cls.expected_merged_reverse_df = pd.DataFrame(
+            {'Mass': [30, 10, 20],
+             'Target': ['Target3, Target5, Target7', 'Target1, Target4,' + \
+             ' Target6', 'Target2']},
             columns=['Mass', 'Target'])
 
     @classmethod
@@ -98,6 +127,13 @@ class TestPanel(unittest.TestCase):
 
         pd.testing.assert_frame_equal(loaded, self.expected_df)
 
+    def test_read_unique_simple_panel(self):
+        self.write_csv_string(self.unique_simple_csv)
+
+        loaded = panels.read_csv(self.filename)
+
+        pd.testing.assert_frame_equal(loaded, self.unique_expected_df)
+
     def test_read_tracker_panel(self):
         self.write_csv_string(self.tracker_csv)
 
@@ -119,6 +155,19 @@ class TestPanel(unittest.TestCase):
 
         pd.testing.assert_frame_equal(loaded, self.expected_df)
 
+    def test_merge_panels_with_repeated_masses(self):
+        self.write_csv_string(self.forwards_merge_csv)
+
+        loaded = panels.read_csv(self.filename)
+
+        pd.testing.assert_frame_equal(loaded, self.expected_merged_df)
+
+    def test_merge_panels_with_repeated_masses_reverse(self):
+        self.write_csv_string(self.backwards_merge_csv)
+
+        loaded = panels.read_csv(self.filename)
+
+        pd.testing.assert_frame_equal(loaded, self.expected_merged_reverse_df)
 
 if __name__ == '__main__':
     unittest.main()

--- a/mibidata/tests/test_panels.py
+++ b/mibidata/tests/test_panels.py
@@ -20,9 +20,6 @@ class TestPanel(unittest.TestCase):
         cls.simple_csv = 'Mass,Target\n10,Target1\n20,Target2\n30,Target3\n' + \
                          '20,Target4'
 
-        cls.unique_simple_csv = 'Mass,Target\n10,Target1\n20,Target2\n30,' + \
-        'Target3'
-
         cls.tracker_csv = 'Panel ID,0\nPanel Name,The Panel,\nProject ID,0\n' +\
             'Project Name,The Project\nManufacture Data,2018-04-25\n,' +\
             'Description,It has a panel\n\n' +\
@@ -75,34 +72,15 @@ class TestPanel(unittest.TestCase):
             '002,Target3,C,30,P\n' +\
             '004,Target4,D,20,Ne'
 
-        cls.forwards_merge_csv = 'Mass,Target\n10,Target1\n20,Target2\n' + \
-                         '30,Target3\n10,Target4\n30,Target5\n10,Target6\n' + \
-                         '30,Target7'
-
-        cls.backwards_merge_csv = 'Mass,Target\n30,Target7\n10,Target6\n' + \
-                         '30,Target5\n10,Target4\n30,Target3\n20,Target2\n' + \
-                         '10,Target1'
-
         cls.expected_df = pd.DataFrame(
             {'Mass': [10, 20, 30],
              'Target': ['Target1', 'Target2, Target4', 'Target3']},
             columns=['Mass', 'Target'])
 
-        cls.unique_expected_df = pd.DataFrame(
-            {'Mass': [10, 20, 30],
-             'Target': ['Target1', 'Target2', 'Target3']},
-            columns=['Mass', 'Target'])
-
-        cls.expected_merged_df = pd.DataFrame(
+        cls.expected_merge_df = pd.DataFrame(
             {'Mass': [10, 20, 30],
              'Target': ['Target1, Target4, Target6', 'Target2', 'Target3,' + \
              ' Target5, Target7']},
-            columns=['Mass', 'Target'])
-
-        cls.expected_merged_reverse_df = pd.DataFrame(
-            {'Mass': [30, 10, 20],
-             'Target': ['Target3, Target5, Target7', 'Target1, Target4,' + \
-             ' Target6', 'Target2']},
             columns=['Mass', 'Target'])
 
     @classmethod
@@ -127,13 +105,6 @@ class TestPanel(unittest.TestCase):
 
         pd.testing.assert_frame_equal(loaded, self.expected_df)
 
-    def test_read_unique_simple_panel(self):
-        self.write_csv_string(self.unique_simple_csv)
-
-        loaded = panels.read_csv(self.filename)
-
-        pd.testing.assert_frame_equal(loaded, self.unique_expected_df)
-
     def test_read_tracker_panel(self):
         self.write_csv_string(self.tracker_csv)
 
@@ -155,19 +126,36 @@ class TestPanel(unittest.TestCase):
 
         pd.testing.assert_frame_equal(loaded, self.expected_df)
 
+    def test_merge_panels_with_unique_masses(self):
+        df_input = pd.DataFrame(
+            {'Mass': [10, 20, 30, 40],
+             'Target': ['Target1', 'Target2', 'Target3', 'Target4']},
+            columns=['Mass', 'Target'])
+        unique_merge_df = panels._merge_masses(df_input)
+
+        expected_df = df_input
+        pd.testing.assert_frame_equal(unique_merge_df, expected_df)
+
     def test_merge_panels_with_repeated_masses(self):
-        self.write_csv_string(self.forwards_merge_csv)
+        df_input = pd.DataFrame(
+            {'Mass': [10, 20, 30, 10, 30, 10, 30],
+             'Target': ['Target1', 'Target2', 'Target3', 'Target4',
+                        'Target5', 'Target6', 'Target7']},
+            columns=['Mass', 'Target'])
+        forward_merge_df = panels._merge_masses(df_input)
 
-        loaded = panels.read_csv(self.filename)
+        pd.testing.assert_frame_equal(forward_merge_df, self.expected_merge_df)
 
-        pd.testing.assert_frame_equal(loaded, self.expected_merged_df)
+    def test_merge_panels_with_repeated_masses_scrambled(self):
+        df_input = pd.DataFrame(
+            {'Mass': [10, 20, 30, 10, 10, 30, 30],
+             'Target': ['Target6', 'Target2', 'Target5', 'Target1',
+                        'Target4', 'Target7', 'Target3']},
+            columns=['Mass', 'Target'])
+        scramble_merge_df = panels._merge_masses(df_input)
 
-    def test_merge_panels_with_repeated_masses_reverse(self):
-        self.write_csv_string(self.backwards_merge_csv)
+        pd.testing.assert_frame_equal(scramble_merge_df, self.expected_merge_df)
 
-        loaded = panels.read_csv(self.filename)
-
-        pd.testing.assert_frame_equal(loaded, self.expected_merged_reverse_df)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
We have "HLA Class 1" and "Na-K-ATPase" on 176, but they appear twice on the target list because we probably did not enforce their order when combining their names.
