### PR TITLE
MibiRequests can be initialized with JWT for mibitracker authentication

### DIFF
--- a/mibitracker/request_helpers.py
+++ b/mibitracker/request_helpers.py
@@ -80,6 +80,7 @@ class MibiRequests():
             self.session.headers.update({
                 'Authorization': 'JWT {}'.format(token)
             })
+            self.session.options(self.url)
         elif email is not None and password is not None:
             self._auth(url, email, password)
         else:
@@ -578,6 +579,10 @@ class StatusCheckedSession(requests.Session):
 
     def get(self, *args, **kwargs):
         response = super().get(*args, **kwargs)
+        return self._check_status(response)
+
+    def options(self, *args, **kwargs):
+        response = super().options(*args, **kwargs)
         return self._check_status(response)
 
     def post(self, *args, **kwargs):

--- a/mibitracker/request_helpers.py
+++ b/mibitracker/request_helpers.py
@@ -43,6 +43,7 @@ class MibiRequests():
             ``'https://backend-dot-mibitracker-demo.appspot.com'``.
         email: The string email address of your MibiTracker account.
         password: The string password of your MibiTracker account.
+        token: A JSON Web Token (JWT) to validate a MibiTracker session.
         retries: The max number of retries for HTTP status errors. Defaults
             to ``MAX_RETRIES`` which is set to 3.
         retry_methods: The HTTP methods to retry. Defaults to

--- a/mibitracker/request_helpers.py
+++ b/mibitracker/request_helpers.py
@@ -63,9 +63,9 @@ class MibiRequests():
 
     def __init__(self,
                  url,
-                 email,
-                 password,
-                 token,
+                 email=None,
+                 password=None,
+                 token=None,
                  retries=MAX_RETRIES,
                  retry_methods=RETRY_METHOD_WHITELIST,
                  retry_codes=RETRY_STATUS_CODES):
@@ -75,12 +75,14 @@ class MibiRequests():
 
         # Provide either an email and password, or a token
         # The token will be used in lieu of email and password if provided
-        if token:
+        if token is not None:
             self.session.headers.update({
                 'Authorization': 'JWT {}'.format(token)
             })
-        else:
+        elif email is not None and password is not None:
             self._auth(url, email, password)
+        else:
+            raise ValueError('Provide either both an email and password or a token')
 
         retry = Retry(status=retries, method_whitelist=retry_methods,
                       status_forcelist=retry_codes, backoff_factor=0.3)

--- a/mibitracker/request_helpers.py
+++ b/mibitracker/request_helpers.py
@@ -61,13 +61,26 @@ class MibiRequests():
             response's status code is >= 400.
     """
 
-    def __init__(self, url, email, password, retries=MAX_RETRIES,
+    def __init__(self,
+                 url,
+                 email,
+                 password,
+                 token,
+                 retries=MAX_RETRIES,
                  retry_methods=RETRY_METHOD_WHITELIST,
                  retry_codes=RETRY_STATUS_CODES):
 
         self.url = url.rstrip('/')  # We add this as part of request params
         self.session = StatusCheckedSession()
-        self._auth(url, email, password)
+
+        # Provide either an email and password, or a token
+        # The token will be used in lieu of email and password if provided
+        if token:
+            self.session.headers.update({
+                'Authorization': 'JWT {}'.format(token)
+            })
+        else:
+            self._auth(url, email, password)
 
         retry = Retry(status=retries, method_whitelist=retry_methods,
                       status_forcelist=retry_codes, backoff_factor=0.3)

--- a/mibitracker/request_helpers.py
+++ b/mibitracker/request_helpers.py
@@ -82,7 +82,9 @@ class MibiRequests():
         elif email is not None and password is not None:
             self._auth(url, email, password)
         else:
-            raise ValueError('Provide either both an email and password or a token')
+            raise ValueError(
+                'Provide either both an email and password or a token'
+            )
 
         retry = Retry(status=retries, method_whitelist=retry_methods,
                       status_forcelist=retry_codes, backoff_factor=0.3)

--- a/mibitracker/tests/test_request_helpers.py
+++ b/mibitracker/tests/test_request_helpers.py
@@ -39,6 +39,36 @@ class TestMibiRequests(unittest.TestCase):
     def tearDown(self):
         self.mock_auth.stop()
 
+    def test_initializing_with_token(self):
+        fake_token = """
+            eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+        """
+        try:
+            request_helpers.MibiRequests(
+                'https://mibitracker-instance.ionpath.com',
+                None,
+                None,
+                fake_token
+            )
+        except ValueError as e:
+            self.fail(e)
+
+    def test_parameter_validation(self):
+        try:
+            request_helpers.MibiRequests(
+                'https://mibitracker-instance.ionpath.com',
+                None,
+                None,
+                None
+            )
+        except ValueError:
+            return
+
+        self.fail(
+            'MibiRequests should fail to initialize\
+                without email and password or token'
+        )
+
     def test_prepare_route(self):
         self.assertEqual(self.mtu._prepare_route('/images/'), '/images/')
         self.assertEqual(self.mtu._prepare_route('images/'), '/images/')

--- a/mibitracker/tests/test_request_helpers.py
+++ b/mibitracker/tests/test_request_helpers.py
@@ -39,7 +39,8 @@ class TestMibiRequests(unittest.TestCase):
     def tearDown(self):
         self.mock_auth.stop()
 
-    def test_initializing_with_token(self):
+    @patch('requests.Session.options')
+    def test_initializing_with_token(self, mock_option):
         fake_token = """
             eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
         """
@@ -50,24 +51,35 @@ class TestMibiRequests(unittest.TestCase):
                 None,
                 fake_token
             )
+            mock_option.assert_called_once_with(
+                'https://mibitracker-instance.ionpath.com'
+            )
         except ValueError as e:
             self.fail(e)
 
+    @patch('requests.Session.options')
+    def test_initializing_with_bad_token(self, mock_option):
+        bad_token = """
+            bad_token
+        """
+        mock_option.side_effect = HTTPError()
+
+        with self.assertRaises(HTTPError):
+            request_helpers.MibiRequests(
+                'https://mibitracker-instance.ionpath.com',
+                None,
+                None,
+                bad_token
+            )
+
     def test_parameter_validation(self):
-        try:
+        with self.assertRaises(ValueError):
             request_helpers.MibiRequests(
                 'https://mibitracker-instance.ionpath.com',
                 None,
                 None,
                 None
             )
-        except ValueError:
-            return
-
-        self.fail(
-            'MibiRequests should fail to initialize\
-                without email and password or token'
-        )
 
     def test_prepare_route(self):
         self.assertEqual(self.mtu._prepare_route('/images/'), '/images/')


### PR DESCRIPTION
 `MibiRequests` has a new signature.

It will now accept either a JWT token or an email or password.