### PR TITLE
DPPA-429: run_id is optional for /upload_mibitiff/ but will become mandatory in v1.1

### DIFF
--- a/mibitracker/request_helpers.py
+++ b/mibitracker/request_helpers.py
@@ -348,7 +348,7 @@ class MibiRequests():
         response.raise_for_status()
         return response
 
-    def upload_mibitiff(self, tiff_file, run_id):
+    def upload_mibitiff(self, tiff_file, run_id=None):
         """Uploads a single TIFF to the MibiTracker.
 
         This uses the 'run' and 'folder' fields in the MibiTiff's description to
@@ -370,7 +370,8 @@ class MibiRequests():
             ValueError: Raised if run_id is None.
         """
         if run_id is None:
-            raise ValueError('run_id cannot be None')
+            raise ValueError(
+                'run_id is mandatory in MIBitracker >=v1.1 and cannot be None')
         response = self.get('/upload_mibitiff/sign_tiff_url/').json()
         try:
             with open(tiff_file, 'rb') as fh:

--- a/mibitracker/request_helpers.py
+++ b/mibitracker/request_helpers.py
@@ -348,7 +348,7 @@ class MibiRequests():
         response.raise_for_status()
         return response
 
-    def upload_mibitiff(self, tiff_file, run_id=None):
+    def upload_mibitiff(self, tiff_file, run_id):
         """Uploads a single TIFF to the MibiTracker.
 
         This uses the 'run' and 'folder' fields in the MibiTiff's description to
@@ -367,10 +367,10 @@ class MibiRequests():
 
         Raises:
             TypeError: Raised if tiff_file is not a string path or file object.
+            ValueError: Raised if run_id is None.
         """
         if run_id is None:
-            warnings.warn('Specifying the run_id is recommended and may become '
-                          'mandatory in the future.', FutureWarning)
+            raise ValueError('run_id cannot be None')
         response = self.get('/upload_mibitiff/sign_tiff_url/').json()
         try:
             with open(tiff_file, 'rb') as fh:

--- a/mibitracker/tests/test_request_helpers.py
+++ b/mibitracker/tests/test_request_helpers.py
@@ -15,7 +15,6 @@ import os
 import shutil
 import tempfile
 import unittest
-import warnings
 
 from mock import patch
 import requests

--- a/mibitracker/tests/test_request_helpers.py
+++ b/mibitracker/tests/test_request_helpers.py
@@ -179,30 +179,10 @@ class TestMibiRequests(unittest.TestCase):
             headers={'content-type': 'application/json'}
         )
 
-    @patch.object(request_helpers.MibiRequests, '_upload_mibitiff')
-    def test_upload_mibitiff_without_run_id(self, mock_upload):
+    def test_upload_mibitiff_without_run_id(self):
         buf = io.BytesIO()
-        response = {
-            'location': 'some_path',
-            'url': 'http://somewhere'
-        }
-        expected_data = {
-            'location': response['location'],
-            'run_id': None,
-        }
-        with warnings.catch_warnings(record=True) as warned:
-            warnings.simplefilter('always')
-            with patch.object(self.mtu, 'get') as mock_get:
-                mock_get().json.return_value = response
-                with patch.object(self.mtu, 'post') as mock_post:
-                    self.mtu.upload_mibitiff(buf)
-        mock_post.assert_called_once_with(
-            '/upload_mibitiff/',
-            data=json.dumps(expected_data),
-            headers={'content-type': 'application/json'}
-        )
-        self.assertEqual(len(warned), 1)
-        self.assertTrue(issubclass(warned[0].category, FutureWarning))
+        with self.assertRaises(ValueError):
+            self.mtu.upload_mibitiff(buf, None)
 
     @patch.object(request_helpers.MibiRequests, '_upload_channel')
     def test_upload_channel_missing_filename(self, mock_upload):


### PR DESCRIPTION
Closes #51 