### PR TITLE
MIC-1203 Validate and convert metadata formats in setters.

### DIFF
--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -161,6 +161,7 @@ class MibiImage():
 
     @property
     def point_name(self):
+        """Return fov_name instead of deprecated point_name."""
         return self.fov_name
 
     @point_name.setter

--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -168,7 +168,7 @@ class MibiImage():
         """Convert deprecated point_name to fov_name."""
         warnings.warn('The "point_name" attribute is deprecated. '
                       'Setting "fov_name" to "{}".'.format(value))
-        self.fov_name = value
+        self.fov_name = value  # pylint: disable=attribute-defined-outside-init
 
     @property
     def folder(self):
@@ -184,8 +184,6 @@ class MibiImage():
                     'The "fov_id" attribute is now required if "folder" is '
                     'specified. Setting "fov_id" to {}.'.format(fov))
                 self._fov_id = fov
-                self._folder = value
-                return
             elif self.fov_id != fov:
                 raise ValueError('fov_id must match folder, but here '
                                  'folder={} and you are trying to set fov_id '
@@ -203,14 +201,12 @@ class MibiImage():
             warnings.warn(
                 'The "folder" attribute is required if "fov_id" is specified. '
                 'Setting "folder" to {}.'.format(value))
-            self._fov_id = value
             self._folder = value
         elif self.folder and value != self.folder.split('/')[0]:
             raise ValueError('fov_id must match folder, but here '
                              'folder={} and you are trying to set fov_id '
                              'to {}.'.format(self.folder, value))
-        else:
-            self._fov_id = value
+        self._fov_id = value
 
     @property
     def channels(self):

--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -34,50 +34,53 @@ class MibiImage():
             metadata. A list of required keys follows; however, the
             user can define other metadata key-value pairs that will be added
             as attributes to the class instance in use.
-            run: A string name of the run during which this image was acquired.
-            date: The run date. It can either be a datetime object, or a string.
-                If a string, it will be parsed according to the
-                `datetime_format``.
-            coordinates: A tuple of (x, y) stage coordinates at which the image
-                was acquired; stage coordinates should be in microns.
-            size: A float size of the image width/height in  :math:`\\mu m`.
-            slide: A string or integer slide ID.
-            fov_id: A string identifying the FOV within the run, i.e. 'FOV1' in
-                MIBIcontrol or 'Point1' in earlier versions.
-            fov_name: A user-defined string name for the FOV as assigned before
-                the run. In prior versions this was called 'point_name'.
-            folder: The folder name for this image as determined by the
+
+            * run: A string name of the run during which this image was
+                acquired.
+            * date: The run date. It can either be a datetime object,
+                or a string. If a string, it will be parsed according to the
+                ``datetime_format``.
+            * coordinates: A tuple of (x, y) stage coordinates at which the
+                image was acquired; stage coordinates should be in microns.
+            * size: A float size of the image width/height in  :math:`\\mu m`.
+            * slide: A string or integer slide ID.
+            * fov_id: A string identifying the FOV within the run,
+                i.e. 'FOV1' in MIBIcontrol or 'Point1' in earlier versions.
+            * fov_name: A user-defined string name for the FOV as assigned
+                before the run. In prior versions this was called 'point_name'.
+            * folder: The folder name for this image as determined by the
                 acquisition software. For data generated from MIBIcontrol
                 software, this will the same as the fov_id.
-            dwell: A float pixel dwell time in :math:`ms`.
-            scans: A comma-separated list of image scan numbers.
-            aperture: A string name of the aperture used during image
+            * dwell: A float pixel dwell time in :math:`ms`.
+            * scans: A comma-separated list of image scan numbers.
+            * aperture: A string name of the aperture used during image
                 acquisition.
-            instrument: A string identifier for the instrument used.
-            tissue: A string name of the tissue type.
-            panel: A string name of the panel used to stain the tissue.
-            version: A string identifier for the software version used.
-            datetime_format: The optional format of the date, if given as a
+            * instrument: A string identifier for the instrument used.
+            * tissue: A string name of the tissue type.
+            * panel: A string name of the panel used to stain the tissue.
+            * version: A string identifier for the software version used.
+            * datetime_format: The optional format of the date, if given as a
                 string. Defaults to ``'%Y-%m-%dT%H:%M:%S'``.
-            mass_offset: Mass offset parameter used for mass calibration.
-            mass_gain: Mass gain used for mass calibration.
-            time_resolution: Parameter used for mass calibration.
-            miscalibrated: Whether or not there was significant difference
+            * mass_offset: Mass offset parameter used for mass calibration.
+            * mass_gain: Mass gain used for mass calibration.
+            * time_resolution: Parameter used for mass calibration.
+            * miscalibrated: Whether or not there was significant difference
                 between peak locations after mass recalibration.
-            check_reg: Whether or not the maximum shift between depths is higher
-                than a threshold.
-            filename: The name of the instrument file containing the run
+            * check_reg: Whether or not the maximum shift between depths is
+                higher than a threshold.
+            * filename: The name of the instrument file containing the run
                 metadata.
-            description: String describing any additional information about the
-                image.
+            * description: String describing any additional information about
+                the image.
 
     Raises:
         ValueError: Raised if
-            - the shape of data does not match length of channels.
-            - the channel names are not unique.
-            - the masses (if included in channel tuples) are not unique.
-            - the targets (if included in channel tuples) are not unique.
-            - the fov_id doesn't match the point in folder, unless the call
+
+            * the shape of data does not match length of channels.
+            * the channel names are not unique.
+            * the masses (if included in channel tuples) are not unique.
+            * the targets (if included in channel tuples) are not unique.
+            * the fov_id doesn't match the point in folder, unless the call
                 is using the old point name format, in which case, only a
                 warning is shown.
 
@@ -91,42 +94,44 @@ class MibiImage():
             metadata. A list of required keys follows; however, the
             user can define other metadata key-value pairs that will be added
             as attributes to the class instance in use.
-            run: A string name of the run during which this image was acquired.
-            date: The run date. It can either be a datetime object, or a string.
-                If a string, it will be parsed according to the
-                `datetime_format``.
-            coordinates: A tuple of (x, y) stage coordinates at which the image
-                was acquired; stage coordinates should be in microns.
-            size: A float size of the image width/height in  :math:`\\mu m`.
-            slide: A string or integer slide ID.
-            fov_id: A string identifying the FOV within the run, i.e. 'FOV1' in
-                MIBIcontrol or 'Point1' in earlier versions.
-            fov_name: A user-defined string name for the FOV as assigned before
-                the run. In prior versions this was called 'point_name'.
-            folder: The folder name for this image as determined by the
+
+            * run: A string name of the run during which this image was
+                acquired.
+            * date: The run date. It can either be a datetime object,
+                or a string. If a string, it will be parsed according to the
+                ``datetime_format``.
+            * coordinates: A tuple of (x, y) stage coordinates at which the
+                image was acquired; stage coordinates should be in microns.
+            * size: A float size of the image width/height in  :math:`\\mu m`.
+            * slide: A string or integer slide ID.
+            * fov_id: A string identifying the FOV within the run,
+                i.e. 'FOV1' in MIBIcontrol or 'Point1' in earlier versions.
+            * fov_name: A user-defined string name for the FOV as assigned
+                before the run. In prior versions this was called 'point_name'.
+            * folder: The folder name for this image as determined by the
                 acquisition software. For data generated from MIBIcontrol
                 software, this will the same as the fov_id.
-            dwell: A float pixel dwell time in :math:`ms`.
-            scans: A comma-separated list of image scan numbers.
-            aperture: A string name of the aperture used during image
+            * dwell: A float pixel dwell time in :math:`ms`.
+            * scans: A comma-separated list of image scan numbers.
+            * aperture: A string name of the aperture used during image
                 acquisition.
-            instrument: A string identifier for the instrument used.
-            tissue: A string name of the tissue type.
-            panel: A string name of the panel used to stain the tissue.
-            version: A string identifier for the software version used.
-            datetime_format: The optional format of the date, if given as a
+            * instrument: A string identifier for the instrument used.
+            * tissue: A string name of the tissue type.
+            * panel: A string name of the panel used to stain the tissue.
+            * version: A string identifier for the software version used.
+            * datetime_format: The optional format of the date, if given as a
                 string. Defaults to ``'%Y-%m-%dT%H:%M:%S'``.
-            mass_offset: Mass offset parameter used for mass calibration.
-            mass_gain: Mass gain used for mass calibration.
-            time_resolution: Parameter used for mass calibration.
-            miscalibrated: Whether or not there was significant difference
+            * mass_offset: Mass offset parameter used for mass calibration.
+            * mass_gain: Mass gain used for mass calibration.
+            * time_resolution: Parameter used for mass calibration.
+            * miscalibrated: Whether or not there was significant difference
                 between peak locations after mass recalibration.
-            check_reg: Whether or not the maximum shift between depths is higher
-                than a threshold.
-            filename: The name of the instrument file containing the run
+            * check_reg: Whether or not the maximum shift between depths is
+                higher than a threshold.
+            * filename: The name of the instrument file containing the run
                 metadata.
-            description: String describing any additional information about the
-                image.
+            * description: String describing any additional information about
+                the image.
     """
 
     def __init__(self, data, channels, **kwargs):
@@ -156,12 +161,12 @@ class MibiImage():
 
         # whatever remains (if anything) is user-defined metadata
         for k, v in kwargs.items():
-            self._user_defined_attributes.append(k)
             setattr(self, k, v)
+            self._user_defined_attributes.append(k)
 
     @property
     def point_name(self):
-        """Return fov_name instead of deprecated point_name."""
+        """Returns fov_name instead of deprecated point_name."""
         return self.fov_name
 
     @point_name.setter
@@ -170,7 +175,6 @@ class MibiImage():
         warnings.warn('The "point_name" attribute is deprecated. '
                       'Setting "fov_name" to "{}".'.format(value))
         self.fov_name = value  # pylint: disable=attribute-defined-outside-init
-        self._user_defined_attributes.remove('point_name')
 
     @property
     def folder(self):

--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -156,8 +156,8 @@ class MibiImage():
 
         # whatever remains (if anything) is user-defined metadata
         for k, v in kwargs.items():
-            setattr(self, k, v)
             self._user_defined_attributes.append(k)
+            setattr(self, k, v)
 
     @property
     def point_name(self):
@@ -169,6 +169,7 @@ class MibiImage():
         warnings.warn('The "point_name" attribute is deprecated. '
                       'Setting "fov_name" to "{}".'.format(value))
         self.fov_name = value  # pylint: disable=attribute-defined-outside-init
+        self._user_defined_attributes.remove('point_name')
 
     @property
     def folder(self):

--- a/mibidata/tests/test_mibi_image.py
+++ b/mibidata/tests/test_mibi_image.py
@@ -114,7 +114,7 @@ class TestMibiImage(unittest.TestCase):
             image = mi.MibiImage(TEST_DATA, TUPLE_LABELS, **OLD_METADATA)
         self.assertEqual(image.fov_id, OLD_METADATA['folder'].split('/')[0])
         self.assertEqual(image.fov_name, OLD_METADATA['point_name'])
-        self.assertEqual(len(image._user_defined_attributes), 0)
+        self.assertEqual(image._user_defined_attributes, ['point_name'])
 
     def test_check_fov_id(self):
         image = mi.MibiImage(TEST_DATA, TUPLE_LABELS)
@@ -201,9 +201,9 @@ class TestMibiImage(unittest.TestCase):
         metadata['fov_name'] = metadata['point_name']
         metadata['fov_id'] = metadata['folder'].split('/')[0]
         metadata['description'] = None
-        del metadata['point_name']
         self.assertEqual(image.metadata(), metadata)
-        self.assertEqual(len(image._user_defined_attributes), 0)
+        # point_name is retained as user-defined
+        self.assertEqual(image._user_defined_attributes, ['point_name'])
 
     def test_channel_inds_single_channel(self):
         image = mi.MibiImage(TEST_DATA, STRING_LABELS)

--- a/mibidata/tests/test_mibi_image.py
+++ b/mibidata/tests/test_mibi_image.py
@@ -114,20 +114,17 @@ class TestMibiImage(unittest.TestCase):
             image = mi.MibiImage(TEST_DATA, TUPLE_LABELS, **OLD_METADATA)
         self.assertEqual(image.fov_id, OLD_METADATA['folder'].split('/')[0])
         self.assertEqual(image.fov_name, OLD_METADATA['point_name'])
-        self.assertEqual(len(image._user_defined_attributes), 0)
+        self.assertEqual(image._user_defined_attributes, ['point_name'])
 
     def test_check_fov_id(self):
         image = mi.MibiImage(TEST_DATA, TUPLE_LABELS)
         image.fov_id = 'Point2'
         image.folder = 'Point2/RowNumber0/Depth_Profile0'
         image.fov_name = 'R1C3_Tonsil'
-        image._check_fov_id()
-        image.fov_id = 'Point99'
         with self.assertRaises(ValueError):
-            image._check_fov_id()
-        image.fov_id = None
+            image.fov_id = 'Point99'
         with self.assertRaises(ValueError):
-            image._check_fov_id()
+            image.fov_id = None
 
     def test_equality(self):
         first = mi.MibiImage(TEST_DATA, STRING_LABELS)
@@ -203,10 +200,10 @@ class TestMibiImage(unittest.TestCase):
                                                       mi._DATETIME_FORMAT)
         metadata['fov_name'] = metadata['point_name']
         metadata['fov_id'] = metadata['folder'].split('/')[0]
-        del metadata['point_name']
         metadata['description'] = None
         self.assertEqual(image.metadata(), metadata)
-        self.assertEqual(len(image._user_defined_attributes), 0)
+        # point_name is retained as user-defined
+        self.assertEqual(image._user_defined_attributes, ['point_name'])
 
     def test_channel_inds_single_channel(self):
         image = mi.MibiImage(TEST_DATA, STRING_LABELS)

--- a/mibidata/tests/test_mibi_image.py
+++ b/mibidata/tests/test_mibi_image.py
@@ -114,7 +114,7 @@ class TestMibiImage(unittest.TestCase):
             image = mi.MibiImage(TEST_DATA, TUPLE_LABELS, **OLD_METADATA)
         self.assertEqual(image.fov_id, OLD_METADATA['folder'].split('/')[0])
         self.assertEqual(image.fov_name, OLD_METADATA['point_name'])
-        self.assertEqual(image._user_defined_attributes, ['point_name'])
+        self.assertEqual(len(image._user_defined_attributes), 0)
 
     def test_check_fov_id(self):
         image = mi.MibiImage(TEST_DATA, TUPLE_LABELS)
@@ -201,9 +201,9 @@ class TestMibiImage(unittest.TestCase):
         metadata['fov_name'] = metadata['point_name']
         metadata['fov_id'] = metadata['folder'].split('/')[0]
         metadata['description'] = None
+        del metadata['point_name']
         self.assertEqual(image.metadata(), metadata)
-        # point_name is retained as user-defined
-        self.assertEqual(image._user_defined_attributes, ['point_name'])
+        self.assertEqual(len(image._user_defined_attributes), 0)
 
     def test_channel_inds_single_channel(self):
         image = mi.MibiImage(TEST_DATA, STRING_LABELS)

--- a/mibidata/tests/test_tiff.py
+++ b/mibidata/tests/test_tiff.py
@@ -206,6 +206,7 @@ class TestWriteReadTiff(unittest.TestCase):
         metadata = tiff.info(self.filename)
         expected = METADATA.copy()
         expected.update({
+            'point_name': OLD_METADATA['point_name'],
             'conjugates': list(CHANNELS),
             'date': datetime.datetime.strptime(expected['date'],
                                                '%Y-%m-%dT%H:%M:%S'),
@@ -222,10 +223,6 @@ class TestWriteReadTiff(unittest.TestCase):
         })
         del expected['description']
         del expected['version']
-        for key, val in metadata.items():
-            print(key)
-            if val != expected.get(key):
-                print(val, expected.get(key))
         self.assertEqual(metadata, expected)
 
     def test_convert_from_previous(self):
@@ -249,8 +246,6 @@ class TestWriteReadTiff(unittest.TestCase):
 
         tiff.write(self.filename, unordered_image)
         image = tiff.read(self.filename)
-        print(image.metadata())
-        print(self.image.metadata())
         self.assertEqual(image, self.image)
 
     def test_write_single_channel_tiffs(self):

--- a/mibidata/tests/test_tiff.py
+++ b/mibidata/tests/test_tiff.py
@@ -206,6 +206,7 @@ class TestWriteReadTiff(unittest.TestCase):
         metadata = tiff.info(self.filename)
         expected = METADATA.copy()
         expected.update({
+            'point_name': OLD_METADATA['point_name'],
             'conjugates': list(CHANNELS),
             'date': datetime.datetime.strptime(expected['date'],
                                                '%Y-%m-%dT%H:%M:%S'),

--- a/mibidata/tests/test_tiff.py
+++ b/mibidata/tests/test_tiff.py
@@ -206,7 +206,6 @@ class TestWriteReadTiff(unittest.TestCase):
         metadata = tiff.info(self.filename)
         expected = METADATA.copy()
         expected.update({
-            'point_name': OLD_METADATA['point_name'],
             'conjugates': list(CHANNELS),
             'date': datetime.datetime.strptime(expected['date'],
                                                '%Y-%m-%dT%H:%M:%S'),


### PR DESCRIPTION
This follow-up to DPPA-516 allows the validation and conversion of old metadata formats to work when set directly on a MibiImage instance, e.g. `image.point_name = 'R3C1'`. It also better separates the validation for each attribute.