### PR TITLE
DPPA-565: Default to save MIBItiff as float

### DIFF
--- a/mibidata/tests/test_tiff.py
+++ b/mibidata/tests/test_tiff.py
@@ -16,7 +16,7 @@ from skimage.external.tifffile import TiffFile
 from mibidata import mibi_image as mi
 from mibidata import tiff, util
 
-DATA = np.arange(500).reshape(10, 10, 5).astype(np.float)
+DATA = np.arange(500).reshape(10, 10, 5).astype(np.float32)
 SED = np.arange(100).reshape(10, 10)
 CAROUSEL = np.random.randint(0, 255, (4096, 4096, 3), np.uint8)
 X_COORD, Y_COORD = tiff._BOTTOM_LABEL_COORDINATES
@@ -90,7 +90,7 @@ class TestWriteReadTiff(unittest.TestCase):
         self.assertIsNone(sed)
         self.assertIsNone(optical)
         self.assertIsNone(label)
-        self.assertEqual(image.data.dtype, np.float)
+        self.assertEqual(image.data.dtype, np.float32)
 
     def test_default_ranges(self):
         tiff.write(self.filename, self.float_image)
@@ -265,10 +265,10 @@ class TestWriteReadTiff(unittest.TestCase):
 
             np.testing.assert_equal(np.squeeze(tif.data), DATA[:, :, i])
             self.assertTupleEqual(tif.channels, (CHANNELS[i], ))
-            self.assertEqual(tif.data.dtype, np.float)
+            self.assertEqual(tif.data.dtype, np.float32)
 
     def test_tiff_dtype_correct_arguments(self):
-        supported_dtypes = ['float', 'uint16', np.float, np.uint16]
+        supported_dtypes = ['float', 'uint16', np.float32, np.uint16]
         for dtype in supported_dtypes:
             tiff.write(self.filename, self.float_image, multichannel=True,
                        dtype=dtype)
@@ -287,33 +287,33 @@ class TestWriteReadTiff(unittest.TestCase):
     def test_write_float_from_float_tiff_dtype_none(self):
         tiff.write(self.filename, self.float_image, multichannel=True)
         image = tiff.read(self.filename)
-        self.assertEqual(image.data.dtype, np.float)
+        self.assertEqual(image.data.dtype, np.float32)
         np.testing.assert_equal(
-            image.data, self.float_image.data.astype(np.float))
+            image.data, self.float_image.data.astype(np.float32))
 
     def test_write_float_from_float_dtype_float(self):
         tiff.write(self.filename, self.float_image, multichannel=True,
                    dtype='float')
         image = tiff.read(self.filename)
-        self.assertEqual(image.data.dtype, np.float)
+        self.assertEqual(image.data.dtype, np.float32)
         np.testing.assert_equal(
-            image.data, self.float_image.data.astype(np.float))
+            image.data, self.float_image.data.astype(np.float32))
 
     def test_write_float_from_float_dtype_np_float(self):
         tiff.write(self.filename, self.float_image, multichannel=True,
-                   dtype=np.float)
+                   dtype=np.float32)
         image = tiff.read(self.filename)
-        self.assertEqual(image.data.dtype, np.float)
+        self.assertEqual(image.data.dtype, np.float32)
         np.testing.assert_equal(
-            image.data, self.float_image.data.astype(np.float))
+            image.data, self.float_image.data.astype(np.float32))
 
     def test_write_float_from_int_dtype_float(self):
         tiff.write(self.filename, self.int_image, multichannel=True,
                    dtype='float')
         image = tiff.read(self.filename)
-        self.assertEqual(image.data.dtype, np.float)
+        self.assertEqual(image.data.dtype, np.float32)
         np.testing.assert_equal(
-            image.data, self.float_image.data.astype(np.float))
+            image.data, self.float_image.data.astype(np.float32))
 
     def test_write_int_from_int_dtype_none(self):
         tiff.write(self.filename, self.int_image, multichannel=True)

--- a/mibidata/tests/test_tiff.py
+++ b/mibidata/tests/test_tiff.py
@@ -268,7 +268,7 @@ class TestWriteReadTiff(unittest.TestCase):
             self.assertEqual(tif.data.dtype, np.float)
 
     def test_tiff_dtype_correct_arguments(self):
-        supported_dtypes = ['float', 'int', np.float, np.uint16]
+        supported_dtypes = ['float', 'uint16', np.float, np.uint16]
         for dtype in supported_dtypes:
             tiff.write(self.filename, self.float_image, multichannel=True,
                        dtype=dtype)
@@ -339,6 +339,15 @@ class TestWriteReadTiff(unittest.TestCase):
         self.assertEqual(image.data.dtype, np.uint16)
         np.testing.assert_equal(
             image.data, self.float_image.data.astype(np.uint16))
+
+        lossy_image = mi.MibiImage(DATA + 0.001, CHANNELS, **METADATA)
+        with self.assertWarns(UserWarning):
+            tiff.write(self.filename, lossy_image, multichannel=True,
+                       dtype='uint16')
+        image = tiff.read(self.filename)
+        np.testing.assert_equal(
+            image.data, self.float_image.data.astype(np.uint16))
+
 
 
 if __name__ == '__main__':

--- a/mibidata/tests/test_tiff.py
+++ b/mibidata/tests/test_tiff.py
@@ -348,12 +348,9 @@ class TestWriteReadTiff(unittest.TestCase):
 
     def test_write_float_as_uint16_warns(self):
         lossy_image = mi.MibiImage(DATA + 0.001, CHANNELS, **METADATA)
-        with self.assertWarns(UserWarning):
+        with self.assertRaises(ValueError):
             tiff.write(self.filename, lossy_image, multichannel=True,
                        dtype='uint16')
-        image = tiff.read(self.filename)
-        np.testing.assert_equal(
-            image.data, self.float_image.data.astype(np.uint16))
 
 
 if __name__ == '__main__':

--- a/mibidata/tests/test_tiff.py
+++ b/mibidata/tests/test_tiff.py
@@ -268,12 +268,12 @@ class TestWriteReadTiff(unittest.TestCase):
             self.assertEqual(tif.data.dtype, np.float32)
 
     def test_tiff_dtype_correct_arguments(self):
-        supported_dtypes = ['float', 'uint16', np.float32, np.uint16]
+        supported_dtypes = [np.float32, np.uint16]
         for dtype in supported_dtypes:
             tiff.write(self.filename, self.float_image, multichannel=True,
                        dtype=dtype)
 
-        unsupported_types = ['abcdef', np.str, np.bool]
+        unsupported_types = ['abcdef', np.str, np.bool, np.uint8, np.float64]
         for dtype in unsupported_types:
             with self.assertRaises(ValueError):
                 tiff.write(self.filename, self.float_image, multichannel=True,
@@ -284,22 +284,14 @@ class TestWriteReadTiff(unittest.TestCase):
             tiff.write(self.filename, self.int_image, write_float=True)
             tiff.write(self.filename, self.float_image, write_float=False)
 
-    def test_write_float_from_float_tiff_dtype_none(self):
+    def test_write_float32_from_float32_tiff_dtype_none(self):
         tiff.write(self.filename, self.float_image, multichannel=True)
         image = tiff.read(self.filename)
         self.assertEqual(image.data.dtype, np.float32)
         np.testing.assert_equal(
             image.data, self.float_image.data.astype(np.float32))
 
-    def test_write_float_from_float_dtype_float(self):
-        tiff.write(self.filename, self.float_image, multichannel=True,
-                   dtype='float')
-        image = tiff.read(self.filename)
-        self.assertEqual(image.data.dtype, np.float32)
-        np.testing.assert_equal(
-            image.data, self.float_image.data.astype(np.float32))
-
-    def test_write_float_from_float_dtype_np_float(self):
+    def test_write_float32_from_float32_dtype_np_float32(self):
         tiff.write(self.filename, self.float_image, multichannel=True,
                    dtype=np.float32)
         image = tiff.read(self.filename)
@@ -307,30 +299,22 @@ class TestWriteReadTiff(unittest.TestCase):
         np.testing.assert_equal(
             image.data, self.float_image.data.astype(np.float32))
 
-    def test_write_float_from_int_dtype_float(self):
+    def test_write_float32_from_int_dtype_np_float32(self):
         tiff.write(self.filename, self.int_image, multichannel=True,
-                   dtype='float')
+                   dtype=np.float32)
         image = tiff.read(self.filename)
         self.assertEqual(image.data.dtype, np.float32)
         np.testing.assert_equal(
             image.data, self.float_image.data.astype(np.float32))
 
-    def test_write_int_from_int_dtype_none(self):
+    def test_write_uint16_from_uint16_dtype_none(self):
         tiff.write(self.filename, self.int_image, multichannel=True)
         image = tiff.read(self.filename)
         self.assertEqual(image.data.dtype, np.uint16)
         np.testing.assert_equal(
             image.data, self.float_image.data.astype(np.uint16))
 
-    def test_write_int_from_int_dtype_uint16(self):
-        tiff.write(self.filename, self.int_image, multichannel=True,
-                   dtype='uint16')
-        image = tiff.read(self.filename)
-        self.assertEqual(image.data.dtype, np.uint16)
-        np.testing.assert_equal(
-            image.data, self.float_image.data.astype(np.uint16))
-
-    def test_write_int_from_int_dtype_np_uint16(self):
+    def test_write_uint16_from_uint16_dtype_np_uint16(self):
         tiff.write(self.filename, self.int_image, multichannel=True,
                    dtype=np.uint16)
         image = tiff.read(self.filename)
@@ -338,19 +322,36 @@ class TestWriteReadTiff(unittest.TestCase):
         np.testing.assert_equal(
             image.data, self.float_image.data.astype(np.uint16))
 
-    def test_write_int_from_float_dtype_uint16(self):
+    def test_write_uint16_from_float32_dtype_np_uint16(self):
         tiff.write(self.filename, self.float_image, multichannel=True,
-                   dtype='uint16')
+                   dtype=np.uint16)
         image = tiff.read(self.filename)
         self.assertEqual(image.data.dtype, np.uint16)
         np.testing.assert_equal(
             image.data, self.float_image.data.astype(np.uint16))
 
-    def test_write_float_as_uint16_warns(self):
+    def test_write_float32_as_uint16_fails(self):
         lossy_image = mi.MibiImage(DATA + 0.001, CHANNELS, **METADATA)
         with self.assertRaises(ValueError):
             tiff.write(self.filename, lossy_image, multichannel=True,
-                       dtype='uint16')
+                       dtype=np.uint16)
+
+    def test_write_float32_from_float64(self):
+        float64_image = mi.MibiImage(
+            DATA.astype(np.float64), CHANNELS, **METADATA)
+        tiff.write(self.filename, float64_image, multichannel=True)
+        image = tiff.read(self.filename)
+        np.testing.assert_equal(image.data, DATA)
+        self.assertEqual(image.data.dtype, np.float32)
+
+    def test_write_uint16_from_uint8(self):
+        uint8_image = mi.MibiImage(
+            np.random.randint(0, 256, (32, 32, 5), dtype=np.uint8),
+            CHANNELS, **METADATA)
+        tiff.write(self.filename, uint8_image, multichannel=True)
+        image = tiff.read(self.filename)
+        np.testing.assert_equal(image.data, uint8_image.data.astype(np.uint16))
+        self.assertEqual(image.data.dtype, np.uint16)
 
 
 if __name__ == '__main__':

--- a/mibidata/tests/test_tiff.py
+++ b/mibidata/tests/test_tiff.py
@@ -16,7 +16,7 @@ from skimage.external.tifffile import TiffFile
 from mibidata import mibi_image as mi
 from mibidata import tiff, util
 
-DATA = np.arange(500).reshape(10, 10, 5).astype(np.uint16)
+DATA = np.arange(500).reshape(10, 10, 5).astype(np.float)
 SED = np.arange(100).reshape(10, 10)
 CAROUSEL = np.random.randint(0, 255, (4096, 4096, 3), np.uint8)
 X_COORD, Y_COORD = tiff._BOTTOM_LABEL_COORDINATES
@@ -62,11 +62,14 @@ class TestTiffHelpers(unittest.TestCase):
 class TestWriteReadTiff(unittest.TestCase):
 
     def setUp(self):
-        self.image = mi.MibiImage(DATA, CHANNELS, **METADATA)
+        self.float_image = mi.MibiImage(DATA, CHANNELS, **METADATA)
+        self.int_image = mi.MibiImage(
+            DATA.astype(np.uint16), CHANNELS, **METADATA)
         self.image_user_defined_metadata = mi.MibiImage(DATA, CHANNELS,
                                                         **METADATA,
                                                         **USER_DEFINED_METADATA)
-        self.image_old_metadata = mi.MibiImage(DATA, CHANNELS, **OLD_METADATA)
+        self.image_old_metadata = mi.MibiImage(
+            DATA, CHANNELS, **OLD_METADATA)
         self.folder = tempfile.mkdtemp()
         self.filename = os.path.join(self.folder, 'test.tiff')
         self.maxDiff = None
@@ -78,28 +81,28 @@ class TestWriteReadTiff(unittest.TestCase):
         self.assertEqual(tiff.SOFTWARE_VERSION, 'IonpathMIBIv1.0')
 
     def test_sims_only(self):
-        tiff.write(self.filename, self.image)
+        tiff.write(self.filename, self.float_image)
         image = tiff.read(self.filename)
-        self.assertEqual(image, self.image)
+        self.assertEqual(image, self.float_image)
         sims, sed, optical, label = tiff.read(self.filename, sed=True,
                                               optical=True, label=True)
-        self.assertEqual(sims, self.image)
+        self.assertEqual(sims, self.float_image)
         self.assertIsNone(sed)
         self.assertIsNone(optical)
         self.assertIsNone(label)
-        self.assertEqual(image.data.dtype, np.uint16)
+        self.assertEqual(image.data.dtype, np.float)
 
     def test_default_ranges(self):
-        tiff.write(self.filename, self.image)
+        tiff.write(self.filename, self.float_image)
         with TiffFile(self.filename) as tif:
             for i, page in enumerate(tif.pages):
                 self.assertEqual(page.tags['smin_sample_value'].value, 0)
                 self.assertEqual(page.tags['smax_sample_value'].value,
-                                 self.image.data[:, :, i].max())
+                                 self.float_image.data[:, :, i].max())
 
     def test_custom_ranges(self):
         ranges = list(zip([1]*5, range(2, 7)))
-        tiff.write(self.filename, self.image, ranges=ranges)
+        tiff.write(self.filename, self.float_image, ranges=ranges)
         with TiffFile(self.filename) as tif:
             for i, page in enumerate(tif.pages):
                 self.assertEqual(page.tags['smin_sample_value'].value,
@@ -109,32 +112,32 @@ class TestWriteReadTiff(unittest.TestCase):
 
 
     def test_sims_and_sed(self):
-        tiff.write(self.filename, self.image, sed=SED)
+        tiff.write(self.filename, self.float_image, sed=SED)
         image = tiff.read(self.filename)
-        self.assertEqual(image, self.image)
+        self.assertEqual(image, self.float_image)
         sims, sed, optical, label = tiff.read(self.filename, sed=True,
                                               optical=True, label=True)
-        self.assertEqual(sims, self.image)
+        self.assertEqual(sims, self.float_image)
         np.testing.assert_array_equal(sed, SED)
         self.assertIsNone(optical)
         self.assertIsNone(label)
 
     def test_sims_and_sed_and_optical_and_label(self):
-        tiff.write(self.filename, self.image, sed=SED, optical=CAROUSEL)
+        tiff.write(self.filename, self.float_image, sed=SED, optical=CAROUSEL)
         image, sed, optical, label = tiff.read(self.filename, sed=True,
                                                optical=True, label=True)
-        self.assertEqual(image, self.image)
+        self.assertEqual(image, self.float_image)
         np.testing.assert_array_equal(sed, SED)
         np.testing.assert_array_equal(optical, CAROUSEL)
         np.testing.assert_array_equal(label, LABEL)
 
     def test_read_sed_only(self):
-        tiff.write(self.filename, self.image, sed=SED)
+        tiff.write(self.filename, self.float_image, sed=SED)
         sed = tiff.read(self.filename, sims=False, sed=True)
         np.testing.assert_array_equal(sed, SED)
 
     def test_read_optical_and_label_only(self):
-        tiff.write(self.filename, self.image, optical=CAROUSEL)
+        tiff.write(self.filename, self.float_image, optical=CAROUSEL)
         optical, label = tiff.read(self.filename, sims=False,
                                    optical=True, label=True)
         np.testing.assert_array_equal(optical, CAROUSEL)
@@ -176,12 +179,12 @@ class TestWriteReadTiff(unittest.TestCase):
             tiff.read(self.filename)
 
     def test_read_with_invalid_return_types(self):
-        tiff.write(self.filename, self.image)
+        tiff.write(self.filename, self.float_image)
         with self.assertRaises(ValueError):
             tiff.read(self.filename, sims=False)
 
     def test_read_metadata_only(self):
-        tiff.write(self.filename, self.image)
+        tiff.write(self.filename, self.float_image)
         metadata = tiff.info(self.filename)
         expected = METADATA.copy()
         expected.update({
@@ -246,13 +249,13 @@ class TestWriteReadTiff(unittest.TestCase):
 
         tiff.write(self.filename, unordered_image)
         image = tiff.read(self.filename)
-        self.assertEqual(image, self.image)
+        self.assertEqual(image, self.float_image)
 
     def test_write_single_channel_tiffs(self):
 
         basepath = os.path.split(self.filename)[0]
 
-        tiff.write(basepath, self.image, multichannel=False)
+        tiff.write(basepath, self.float_image, multichannel=False)
 
         for i, (_, channel) in enumerate(CHANNELS):
             formatted = util.format_for_filename(channel)
@@ -262,15 +265,75 @@ class TestWriteReadTiff(unittest.TestCase):
 
             np.testing.assert_equal(np.squeeze(tif.data), DATA[:, :, i])
             self.assertTupleEqual(tif.channels, (CHANNELS[i], ))
-            self.assertEqual(tif.data.dtype, np.uint16)
+            self.assertEqual(tif.data.dtype, np.float)
+
+    def test_tiff_dtype_correct_arguments(self):
+        supported_dtypes = ['float', 'int', np.float, np.uint16]
+        for dtype in supported_dtypes:
+            tiff.write(self.filename, self.float_image, multichannel=True,
+                       write_dtype=dtype)
+
+        unsupported_types = ['abcdef', np.str, np.bool]
+        for dtype in unsupported_types:
+            with self.assertRaises(ValueError):
+                tiff.write(self.filename, self.float_image, multichannel=True,
+                           write_dtype=dtype)
 
     def test_write_float_tiff(self):
-
-        tiff.write(self.filename, self.image,
-                   multichannel=True, write_float=True)
+        tiff.write(self.filename, self.float_image, multichannel=True)
         image = tiff.read(self.filename)
-        self.assertEqual(image.data.dtype, np.float32)
-        np.testing.assert_equal(image.data, self.image.data.astype(np.float32))
+        self.assertEqual(image.data.dtype, np.float)
+        np.testing.assert_equal(
+            image.data, self.float_image.data.astype(np.float))
+
+        tiff.write(self.filename, self.float_image, multichannel=True,
+                   write_dtype='float')
+        image = tiff.read(self.filename)
+        self.assertEqual(image.data.dtype, np.float)
+        np.testing.assert_equal(
+            image.data, self.float_image.data.astype(np.float))
+
+        tiff.write(self.filename, self.float_image, multichannel=True,
+                   write_dtype=np.float)
+        image = tiff.read(self.filename)
+        self.assertEqual(image.data.dtype, np.float)
+        np.testing.assert_equal(
+            image.data, self.float_image.data.astype(np.float))
+
+        tiff.write(self.filename, self.int_image, multichannel=True,
+                   write_dtype='float')
+        image = tiff.read(self.filename)
+        self.assertEqual(image.data.dtype, np.float)
+        np.testing.assert_equal(
+            image.data, self.float_image.data.astype(np.float))
+
+    def test_write_int_tiff(self):
+        tiff.write(self.filename, self.int_image, multichannel=True)
+        image = tiff.read(self.filename)
+        self.assertEqual(image.data.dtype, np.uint16)
+        np.testing.assert_equal(
+            image.data, self.float_image.data.astype(np.uint16))
+
+        tiff.write(self.filename, self.int_image, multichannel=True,
+                   write_dtype='int')
+        image = tiff.read(self.filename)
+        self.assertEqual(image.data.dtype, np.uint16)
+        np.testing.assert_equal(
+            image.data, self.float_image.data.astype(np.uint16))
+
+        tiff.write(self.filename, self.int_image, multichannel=True,
+                   write_dtype=np.uint16)
+        image = tiff.read(self.filename)
+        self.assertEqual(image.data.dtype, np.uint16)
+        np.testing.assert_equal(
+            image.data, self.float_image.data.astype(np.uint16))
+
+        tiff.write(self.filename, self.float_image, multichannel=True,
+                   write_dtype='int')
+        image = tiff.read(self.filename)
+        self.assertEqual(image.data.dtype, np.uint16)
+        np.testing.assert_equal(
+            image.data, self.float_image.data.astype(np.uint16))
 
 
 if __name__ == '__main__':

--- a/mibidata/tests/test_tiff.py
+++ b/mibidata/tests/test_tiff.py
@@ -271,13 +271,18 @@ class TestWriteReadTiff(unittest.TestCase):
         supported_dtypes = ['float', 'int', np.float, np.uint16]
         for dtype in supported_dtypes:
             tiff.write(self.filename, self.float_image, multichannel=True,
-                       write_dtype=dtype)
+                       dtype=dtype)
 
         unsupported_types = ['abcdef', np.str, np.bool]
         for dtype in unsupported_types:
             with self.assertRaises(ValueError):
                 tiff.write(self.filename, self.float_image, multichannel=True,
-                           write_dtype=dtype)
+                           dtype=dtype)
+
+    def test_write_float_is_deprecated(self):
+        with self.assertRaises(ValueError):
+            tiff.write(self.filename, self.int_image, write_float=True)
+            tiff.write(self.filename, self.float_image, write_float=False)
 
     def test_write_float_tiff(self):
         tiff.write(self.filename, self.float_image, multichannel=True)
@@ -287,21 +292,21 @@ class TestWriteReadTiff(unittest.TestCase):
             image.data, self.float_image.data.astype(np.float))
 
         tiff.write(self.filename, self.float_image, multichannel=True,
-                   write_dtype='float')
+                   dtype='float')
         image = tiff.read(self.filename)
         self.assertEqual(image.data.dtype, np.float)
         np.testing.assert_equal(
             image.data, self.float_image.data.astype(np.float))
 
         tiff.write(self.filename, self.float_image, multichannel=True,
-                   write_dtype=np.float)
+                   dtype=np.float)
         image = tiff.read(self.filename)
         self.assertEqual(image.data.dtype, np.float)
         np.testing.assert_equal(
             image.data, self.float_image.data.astype(np.float))
 
         tiff.write(self.filename, self.int_image, multichannel=True,
-                   write_dtype='float')
+                   dtype='float')
         image = tiff.read(self.filename)
         self.assertEqual(image.data.dtype, np.float)
         np.testing.assert_equal(
@@ -315,21 +320,21 @@ class TestWriteReadTiff(unittest.TestCase):
             image.data, self.float_image.data.astype(np.uint16))
 
         tiff.write(self.filename, self.int_image, multichannel=True,
-                   write_dtype='int')
+                   dtype='int')
         image = tiff.read(self.filename)
         self.assertEqual(image.data.dtype, np.uint16)
         np.testing.assert_equal(
             image.data, self.float_image.data.astype(np.uint16))
 
         tiff.write(self.filename, self.int_image, multichannel=True,
-                   write_dtype=np.uint16)
+                   dtype=np.uint16)
         image = tiff.read(self.filename)
         self.assertEqual(image.data.dtype, np.uint16)
         np.testing.assert_equal(
             image.data, self.float_image.data.astype(np.uint16))
 
         tiff.write(self.filename, self.float_image, multichannel=True,
-                   write_dtype='int')
+                   dtype='int')
         image = tiff.read(self.filename)
         self.assertEqual(image.data.dtype, np.uint16)
         np.testing.assert_equal(

--- a/mibidata/tests/test_tiff.py
+++ b/mibidata/tests/test_tiff.py
@@ -282,6 +282,7 @@ class TestWriteReadTiff(unittest.TestCase):
     def test_write_float_is_deprecated(self):
         with self.assertRaises(ValueError):
             tiff.write(self.filename, self.int_image, write_float=True)
+        with self.assertRaises(ValueError):
             tiff.write(self.filename, self.float_image, write_float=False)
 
     def test_write_float32_from_float32_tiff_dtype_none(self):

--- a/mibidata/tests/test_tiff.py
+++ b/mibidata/tests/test_tiff.py
@@ -320,7 +320,7 @@ class TestWriteReadTiff(unittest.TestCase):
             image.data, self.float_image.data.astype(np.uint16))
 
         tiff.write(self.filename, self.int_image, multichannel=True,
-                   dtype='int')
+                   dtype='uint16')
         image = tiff.read(self.filename)
         self.assertEqual(image.data.dtype, np.uint16)
         np.testing.assert_equal(
@@ -334,7 +334,7 @@ class TestWriteReadTiff(unittest.TestCase):
             image.data, self.float_image.data.astype(np.uint16))
 
         tiff.write(self.filename, self.float_image, multichannel=True,
-                   dtype='int')
+                   dtype='uint16')
         image = tiff.read(self.filename)
         self.assertEqual(image.data.dtype, np.uint16)
         np.testing.assert_equal(

--- a/mibidata/tests/test_tiff.py
+++ b/mibidata/tests/test_tiff.py
@@ -284,13 +284,14 @@ class TestWriteReadTiff(unittest.TestCase):
             tiff.write(self.filename, self.int_image, write_float=True)
             tiff.write(self.filename, self.float_image, write_float=False)
 
-    def test_write_float_tiff(self):
+    def test_write_float_from_float_tiff_dtype_none(self):
         tiff.write(self.filename, self.float_image, multichannel=True)
         image = tiff.read(self.filename)
         self.assertEqual(image.data.dtype, np.float)
         np.testing.assert_equal(
             image.data, self.float_image.data.astype(np.float))
 
+    def test_write_float_from_float_dtype_float(self):
         tiff.write(self.filename, self.float_image, multichannel=True,
                    dtype='float')
         image = tiff.read(self.filename)
@@ -298,6 +299,7 @@ class TestWriteReadTiff(unittest.TestCase):
         np.testing.assert_equal(
             image.data, self.float_image.data.astype(np.float))
 
+    def test_write_float_from_float_dtype_np_float(self):
         tiff.write(self.filename, self.float_image, multichannel=True,
                    dtype=np.float)
         image = tiff.read(self.filename)
@@ -305,6 +307,7 @@ class TestWriteReadTiff(unittest.TestCase):
         np.testing.assert_equal(
             image.data, self.float_image.data.astype(np.float))
 
+    def test_write_float_from_int_dtype_float(self):
         tiff.write(self.filename, self.int_image, multichannel=True,
                    dtype='float')
         image = tiff.read(self.filename)
@@ -312,13 +315,14 @@ class TestWriteReadTiff(unittest.TestCase):
         np.testing.assert_equal(
             image.data, self.float_image.data.astype(np.float))
 
-    def test_write_int_tiff(self):
+    def test_write_int_from_int_dtype_none(self):
         tiff.write(self.filename, self.int_image, multichannel=True)
         image = tiff.read(self.filename)
         self.assertEqual(image.data.dtype, np.uint16)
         np.testing.assert_equal(
             image.data, self.float_image.data.astype(np.uint16))
 
+    def test_write_int_from_int_dtype_uint16(self):
         tiff.write(self.filename, self.int_image, multichannel=True,
                    dtype='uint16')
         image = tiff.read(self.filename)
@@ -326,6 +330,7 @@ class TestWriteReadTiff(unittest.TestCase):
         np.testing.assert_equal(
             image.data, self.float_image.data.astype(np.uint16))
 
+    def test_write_int_from_int_dtype_np_uint16(self):
         tiff.write(self.filename, self.int_image, multichannel=True,
                    dtype=np.uint16)
         image = tiff.read(self.filename)
@@ -333,6 +338,7 @@ class TestWriteReadTiff(unittest.TestCase):
         np.testing.assert_equal(
             image.data, self.float_image.data.astype(np.uint16))
 
+    def test_write_int_from_float_dtype_uint16(self):
         tiff.write(self.filename, self.float_image, multichannel=True,
                    dtype='uint16')
         image = tiff.read(self.filename)
@@ -340,6 +346,7 @@ class TestWriteReadTiff(unittest.TestCase):
         np.testing.assert_equal(
             image.data, self.float_image.data.astype(np.uint16))
 
+    def test_write_float_as_uint16_warns(self):
         lossy_image = mi.MibiImage(DATA + 0.001, CHANNELS, **METADATA)
         with self.assertWarns(UserWarning):
             tiff.write(self.filename, lossy_image, multichannel=True,
@@ -347,7 +354,6 @@ class TestWriteReadTiff(unittest.TestCase):
         image = tiff.read(self.filename)
         np.testing.assert_equal(
             image.data, self.float_image.data.astype(np.uint16))
-
 
 
 if __name__ == '__main__':

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -65,7 +65,7 @@ def write(filename, image, sed=None, optical=None, ranges=None,
             or a folder of single-channel TIFFs. Defaults to True; if False,
             the sed and optical options are ignored.
         dtype: Forces the image data saved as either float or uint16. Can
-            specify ``'float'`` or ``np.float`` to force data to be saved as
+            specify ``'float'`` or ``np.float32`` to force data to be saved as
             floating point values or ``'uint16'`` or ``np.uint16`` to save as
             unsigned 16-bit integer values. Defaults to None, which saves data
             as its original type. Note that forcing native float image data to
@@ -80,7 +80,7 @@ def write(filename, image, sed=None, optical=None, ranges=None,
             * The image is not a :class:`mibidata.mibi_image.MibiImage` instance
             * The :class:`mibidata.mibi_image.MibiImage` ccoordinates, size,
               masses or targets are None
-            * `dtype` is not one of ``'float'``, ``'uint16'``, ``np.float``,
+            * `dtype` is not one of ``'float'``, ``'uint16'``, ``np.float32``,
               or ``np.uint16``
             * `write_float` has been specified.
     """
@@ -94,7 +94,7 @@ def write(filename, image, sed=None, optical=None, ranges=None,
     if write_float:
         raise ValueError('`write_float` has been deprecated. Please use the '
                          '`dtype` argument instead.')
-    if dtype and not dtype in ['float', 'uint16', np.float, np.uint16]:
+    if dtype and not dtype in ['float', 'uint16', np.float32, np.uint16]:
         raise ValueError('Invalid dtype specification.')
     if not dtype:
         range_dtype = 'I' if\
@@ -102,7 +102,7 @@ def write(filename, image, sed=None, optical=None, ranges=None,
     else:
         range_dtype = 'I' if dtype in ['uint16', np.uint16] else 'd'
 
-    save_dtype = np.uint16 if range_dtype == 'I' else np.float
+    save_dtype = np.uint16 if range_dtype == 'I' else np.float32
     to_save = image.data.astype(save_dtype)
     if not np.all(np.equal(to_save, image.data)):
         warnings.warn('Loss of precision saving data of type '

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -52,7 +52,7 @@ def write(filename, image, sed=None, optical=None, ranges=None,
     Args:
         filename: The path to the target file if multi-channel, or the path to
             a folder if single-channel.
-        image: A ``mibitof.mibi_image.MibiImage`` instance.
+        image: A :class:`mibidata.mibi_image.MibiImage` instance.
         sed: Optional, an array of the SED image data. This is assumed to be
             grayscale even if 3-dimensional, in which case only one channel
             will be used.
@@ -65,25 +65,27 @@ def write(filename, image, sed=None, optical=None, ranges=None,
             or a folder of single-channel TIFFs. Defaults to True; if False,
             the sed and optical options are ignored.
         dtype: Forces the image data saved as either float or uint16. Can
-            specify `'float'` or `np.float` to force data to be saved as
-            floating point values or `'uint16'` or `np.uint16` to save as
+            specify ``'float'`` or ``np.float`` to force data to be saved as
+            floating point values or ``'uint16'`` or ``np.uint16`` to save as
             unsigned 16-bit integer values. Defaults to None, which saves data
             as its original type. Note that forcing native float image data to
             uint16 could result in a loss of precision as values are clipped.
-        write_float: Deprecated, will raise ArgumentError if specified. To
+        write_float: Deprecated, will raise ValueError if specified. To
             specify the dtype of the saved image, please use the `dtype`
             argument instead.
 
     Raises:
         ValueError: Raised if
 
-            * The image is not a ``mibitof.mibi_image.MibiImage`` instance
-            * Ccoordinates, size, masses or targets are None
-            * `dtype` is not one of 'float', 'uint16', np.float, or np.uint16
+            * The image is not a :class:`mibidata.mibi_image.MibiImage` instance
+            * The :class:`mibidata.mibi_image.MibiImage` ccoordinates, size,
+              masses or targets are None
+            * `dtype` is not one of ``'float'``, ``'uint16'``, ``np.float``,
+              or ``np.uint16``
             * `write_float` has been specified.
     """
     if not isinstance(image, mi.MibiImage):
-        raise ValueError('image must be a mibitof.mibi_image.MibiImage '
+        raise ValueError('image must be a mibidata.mibi_image.MibiImage '
                          'instance.')
     if image.coordinates is None or image.size is None:
         raise ValueError('Image coordinates and size must not be None.')
@@ -224,9 +226,10 @@ def read(file, sims=True, sed=False, optical=False, label=False):
     Returns: A tuple of the image types set to True in the parameters, in the
         order SIMS, SED, Optical, Label (but including only those types
         specified). The SIMS data will be returned as a
-        ``mibitof.mibi_image.MibiImage`` instance; the other image types will be
-        returned as numpy arrays. If an image type is selected to be returned
-        but is not present in the image, it will be returned as None.
+        :class:`mibidata.mibi_image.MibiImage` instance; the other image
+        types will be returned as numpy arrays. If an image type is selected to
+        be returned  but is not present in the image, it will be returned as
+        None.
 
     Raises:
         ValueError: Raised if the input file is not of the IonpathMIBI
@@ -345,7 +348,7 @@ def info(filename):
 
     Returns:
         A dictionary of metadata as could be supplied as kwargs to
-        ``mibitof.mibi_image.MibiImage``, except with a ``channels`` key
+        :class:`mibidata.mibi_image.MibiImage`, except with a ``channels`` key
         whose value is a list of (mass, target) tuples.
     """
     metadata = {}

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -91,7 +91,7 @@ def write(filename, image, sed=None, optical=None, ranges=None,
         raise ValueError('Image coordinates and size must not be None.')
     if image.masses is None or image.targets is None:
         raise ValueError('Image channels must contain both masses and targets.')
-    if write_float:
+    if write_float is not None:
         raise ValueError('`write_float` has been deprecated. Please use the '
                          '`dtype` argument instead.')
     if dtype and not dtype in [np.float32, np.uint16]:

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -46,7 +46,7 @@ def _cm_to_micron(arg):
 
 # pylint: disable=too-many-branches,too-many-statements
 def write(filename, image, sed=None, optical=None, ranges=None,
-          multichannel=True, write_float=False):
+          multichannel=True, write_dtype=None):
     """Writes MIBI data to a multipage TIFF.
 
     Args:
@@ -64,16 +64,18 @@ def write(filename, image, sed=None, optical=None, ranges=None,
         multichannel: Boolean for whether to create a single multi-channel TIFF,
             or a folder of single-channel TIFFs. Defaults to True; if False,
             the sed and optical options are ignored.
-        write_float: If True, saves the image data as float32 values (for
-            opening properly in certain software such as Halo). Defaults to
-            False which will save the image data as uint16. Note: setting
-            write_float to True does not normalize or scale the data before
-            saving, however saves the integer counts as floating point numbers.
+        write_dtype: Forces the image data saved as either float or uint16. Can
+            specify `'float'` or `np.float` to force data to be saved as
+            floating point values or `'int'` or `np.uint16` to save as integer
+            values. Defaults to None, which saves data as its original type.
+            Note that forcing native float image data to uint16 could result
+            in a loss of precision as values are clipped.
 
     Raises:
         ValueError: Raised if the image is not a
             ``mibitof.mibi_image.MibiImage`` instance, or if its coordinates,
-            size, masses or targets are None.
+            size, masses or targets are None, or if `write_dtype` is not one
+            of 'float', 'int', np.float, or np.uint16.
     """
     if not isinstance(image, mi.MibiImage):
         raise ValueError('image must be a mibitof.mibi_image.MibiImage '
@@ -82,12 +84,17 @@ def write(filename, image, sed=None, optical=None, ranges=None,
         raise ValueError('Image coordinates and size must not be None.')
     if image.masses is None or image.targets is None:
         raise ValueError('Image channels must contain both masses and targets.')
-    if np.issubdtype(image.data.dtype, np.integer) and not write_float:
-        range_dtype = 'I'
+    if write_dtype and not write_dtype in ['float', 'int', np.float, np.uint16]:
+        raise ValueError('Invalid dtype specification.')
+    if not write_dtype:
+        range_dtype = 'I' if\
+            np.issubdtype(image.data.dtype, np.integer) else 'd'
     else:
-        range_dtype = 'd'
+        range_dtype = 'I' if write_dtype in ['int', np.uint16] else 'd'
+
     if ranges is None:
-        ranges = [(0, m) for m in image.data.max(axis=(0, 1))]
+        dtype_conversion = int if range_dtype == 'I' else float
+        ranges = [(0, dtype_conversion(m)) for m in image.data.max(axis=(0, 1))]
 
     coordinates = [
         (286, '2i', 1, _micron_to_cm(image.coordinates[0])),  # x-position
@@ -132,10 +139,10 @@ def write(filename, image, sed=None, optical=None, ranges=None,
                 max_value = (341, range_dtype, 1, ranges[i][1])
                 page_tags = coordinates + [page_name, min_value, max_value]
 
-                if write_float:
-                    to_save = image.data[:, :, i].astype(np.float32)
+                if range_dtype == 'I':
+                    to_save = image.data[:, :, i].astype(np.uint16)
                 else:
-                    to_save = image.data[:, :, i]
+                    to_save = image.data[:, :, i].astype(np.float)
 
                 infile.save(
                     to_save, compress=6, resolution=resolution,
@@ -179,22 +186,17 @@ def write(filename, image, sed=None, optical=None, ranges=None,
             max_value = (341, range_dtype, 1, ranges[i][1])
             page_tags = coordinates + [page_name, min_value, max_value]
 
-            if write_float:
-                target_filename = os.path.join(
-                    filename, '{}.float.tiff'.format(
-                        util.format_for_filename(image.targets[i])))
-            else:
-                target_filename = os.path.join(
-                    filename, '{}.tiff'.format(
-                        util.format_for_filename(image.targets[i])))
+            target_filename = os.path.join(
+                filename, '{}.tiff'.format(
+                    util.format_for_filename(image.targets[i])))
 
             with TiffWriter(target_filename,
                             software=SOFTWARE_VERSION) as infile:
 
-                if write_float:
-                    to_save = image.data[:, :, i].astype(np.float32)
+                if range_dtype == 'I':
+                    to_save = image.data[:, :, i].astype(np.uint16)
                 else:
-                    to_save = image.data[:, :, i]
+                    to_save = image.data[:, :, i].astype(np.float)
 
                 infile.save(
                     to_save, compress=6, resolution=resolution,

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -153,13 +153,8 @@ def write(filename, image, sed=None, optical=None, ranges=None,
                 max_value = (341, range_dtype, 1, ranges[i][1])
                 page_tags = coordinates + [page_name, min_value, max_value]
 
-                if range_dtype == 'I':
-                    to_save = image.data[:, :, i].astype(np.uint16)
-                else:
-                    to_save = image.data[:, :, i].astype(np.float)
-
                 infile.save(
-                    to_save, compress=6, resolution=resolution,
+                    to_save[:, :, i], compress=6, resolution=resolution,
                     extratags=page_tags, metadata=metadata, datetime=image.date)
             if sed is not None:
                 if sed.ndim > 2:
@@ -207,13 +202,8 @@ def write(filename, image, sed=None, optical=None, ranges=None,
             with TiffWriter(target_filename,
                             software=SOFTWARE_VERSION) as infile:
 
-                if range_dtype == 'I':
-                    to_save = image.data[:, :, i].astype(np.uint16)
-                else:
-                    to_save = image.data[:, :, i].astype(np.float)
-
                 infile.save(
-                    to_save, compress=6, resolution=resolution,
+                    to_save[:, :, i], compress=6, resolution=resolution,
                     metadata=metadata, datetime=image.date,
                     extratags=page_tags)
 

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -96,17 +96,24 @@ def write(filename, image, sed=None, optical=None, ranges=None,
                          '`dtype` argument instead.')
     if dtype and not dtype in ['float', 'uint16', np.float32, np.uint16]:
         raise ValueError('Invalid dtype specification.')
-    if not dtype:
-        range_dtype = 'I' if\
-            np.issubdtype(image.data.dtype, np.integer) else 'd'
-    else:
-        range_dtype = 'I' if dtype in ['uint16', np.uint16] else 'd'
 
-    save_dtype = np.uint16 if range_dtype == 'I' else np.float32
+    if dtype in ['float', np.float32]:
+        save_dtype = np.float32
+        range_dtype = 'd'
+    elif dtype in ['uint16', np.uint16]:
+        save_dtype = np.uint16
+        range_dtype = 'I'
+    elif np.issubdtype(image.data.dtype, np.floating):
+        save_dtype = np.float32
+        range_dtype = 'd'
+    else:
+        save_dtype = np.uint16
+        range_dtype = 'I'
+
     to_save = image.data.astype(save_dtype)
     if not np.all(np.equal(to_save, image.data)):
-        warnings.warn('Loss of precision saving data of type '
-                      f'{image.data.dtype} as {save_dtype}')
+        raise ValueError('Cannot convert data from '
+                         f'{image.data.dtype} to {save_dtype}')
 
     if ranges is None:
         dtype_conversion = int if range_dtype == 'I' else float

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -75,11 +75,12 @@ def write(filename, image, sed=None, optical=None, ranges=None,
             argument instead.
 
     Raises:
-        ValueError: Raised if the image is not a
-            ``mibitof.mibi_image.MibiImage`` instance, or if its coordinates,
-            size, masses or targets are None, or if `dtype` is not one
-            of 'float', 'uint16', np.float, or np.uint16., or if `write_float`
-            has been specified.
+        ValueError: Raised if
+
+            * The image is not a ``mibitof.mibi_image.MibiImage`` instance
+            * Ccoordinates, size, masses or targets are None
+            * `dtype` is not one of 'float', 'uint16', np.float, or np.uint16
+            * `write_float` has been specified.
     """
     if not isinstance(image, mi.MibiImage):
         raise ValueError('image must be a mibitof.mibi_image.MibiImage '
@@ -98,6 +99,12 @@ def write(filename, image, sed=None, optical=None, ranges=None,
             np.issubdtype(image.data.dtype, np.integer) else 'd'
     else:
         range_dtype = 'I' if dtype in ['uint16', np.uint16] else 'd'
+
+    save_dtype = np.uint16 if range_dtype == 'I' else np.float
+    to_save = image.data.astype(save_dtype)
+    if not np.all(np.equal(to_save, image.data)):
+        warnings.warn('Loss of precision saving data of type '
+                      f'{image.data.dtype} as {save_dtype}')
 
     if ranges is None:
         dtype_conversion = int if range_dtype == 'I' else float

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -46,7 +46,7 @@ def _cm_to_micron(arg):
 
 # pylint: disable=too-many-branches,too-many-statements
 def write(filename, image, sed=None, optical=None, ranges=None,
-          multichannel=True, write_dtype=None):
+          multichannel=True, dtype=None, write_float=None):
     """Writes MIBI data to a multipage TIFF.
 
     Args:
@@ -64,18 +64,22 @@ def write(filename, image, sed=None, optical=None, ranges=None,
         multichannel: Boolean for whether to create a single multi-channel TIFF,
             or a folder of single-channel TIFFs. Defaults to True; if False,
             the sed and optical options are ignored.
-        write_dtype: Forces the image data saved as either float or uint16. Can
+        dtype: Forces the image data saved as either float or uint16. Can
             specify `'float'` or `np.float` to force data to be saved as
             floating point values or `'int'` or `np.uint16` to save as integer
             values. Defaults to None, which saves data as its original type.
             Note that forcing native float image data to uint16 could result
             in a loss of precision as values are clipped.
+        write_float: Deprecated, will raise ArgumentError if specified. To
+            specify the dtype of the saved image, please use the `dtype`
+            argument instead.
 
     Raises:
         ValueError: Raised if the image is not a
             ``mibitof.mibi_image.MibiImage`` instance, or if its coordinates,
-            size, masses or targets are None, or if `write_dtype` is not one
-            of 'float', 'int', np.float, or np.uint16.
+            size, masses or targets are None, or if `dtype` is not one
+            of 'float', 'int', np.float, or np.uint16., or if `write_float` has
+            been specified.
     """
     if not isinstance(image, mi.MibiImage):
         raise ValueError('image must be a mibitof.mibi_image.MibiImage '
@@ -84,13 +88,16 @@ def write(filename, image, sed=None, optical=None, ranges=None,
         raise ValueError('Image coordinates and size must not be None.')
     if image.masses is None or image.targets is None:
         raise ValueError('Image channels must contain both masses and targets.')
-    if write_dtype and not write_dtype in ['float', 'int', np.float, np.uint16]:
+    if write_float:
+        raise ValueError('`write_float` has been deprecated. Please use the '
+                         '`dtype` argument instead.')
+    if dtype and not dtype in ['float', 'int', np.float, np.uint16]:
         raise ValueError('Invalid dtype specification.')
-    if not write_dtype:
+    if not dtype:
         range_dtype = 'I' if\
             np.issubdtype(image.data.dtype, np.integer) else 'd'
     else:
-        range_dtype = 'I' if write_dtype in ['int', np.uint16] else 'd'
+        range_dtype = 'I' if dtype in ['int', np.uint16] else 'd'
 
     if ranges is None:
         dtype_conversion = int if range_dtype == 'I' else float

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -66,10 +66,10 @@ def write(filename, image, sed=None, optical=None, ranges=None,
             the sed and optical options are ignored.
         dtype: Forces the image data saved as either float or uint16. Can
             specify `'float'` or `np.float` to force data to be saved as
-            floating point values or `'int'` or `np.uint16` to save as integer
-            values. Defaults to None, which saves data as its original type.
-            Note that forcing native float image data to uint16 could result
-            in a loss of precision as values are clipped.
+            floating point values or `'uint16'` or `np.uint16` to save as
+            unsigned 16-bit integer values. Defaults to None, which saves data
+            as its original type. Note that forcing native float image data to
+            uint16 could result in a loss of precision as values are clipped.
         write_float: Deprecated, will raise ArgumentError if specified. To
             specify the dtype of the saved image, please use the `dtype`
             argument instead.
@@ -78,8 +78,8 @@ def write(filename, image, sed=None, optical=None, ranges=None,
         ValueError: Raised if the image is not a
             ``mibitof.mibi_image.MibiImage`` instance, or if its coordinates,
             size, masses or targets are None, or if `dtype` is not one
-            of 'float', 'int', np.float, or np.uint16., or if `write_float` has
-            been specified.
+            of 'float', 'uint16', np.float, or np.uint16., or if `write_float`
+            has been specified.
     """
     if not isinstance(image, mi.MibiImage):
         raise ValueError('image must be a mibitof.mibi_image.MibiImage '
@@ -91,13 +91,13 @@ def write(filename, image, sed=None, optical=None, ranges=None,
     if write_float:
         raise ValueError('`write_float` has been deprecated. Please use the '
                          '`dtype` argument instead.')
-    if dtype and not dtype in ['float', 'int', np.float, np.uint16]:
+    if dtype and not dtype in ['float', 'uint16', np.float, np.uint16]:
         raise ValueError('Invalid dtype specification.')
     if not dtype:
         range_dtype = 'I' if\
             np.issubdtype(image.data.dtype, np.integer) else 'd'
     else:
-        range_dtype = 'I' if dtype in ['int', np.uint16] else 'd'
+        range_dtype = 'I' if dtype in ['uint16', np.uint16] else 'd'
 
     if ranges is None:
         dtype_conversion = int if range_dtype == 'I' else float

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -64,11 +64,11 @@ def write(filename, image, sed=None, optical=None, ranges=None,
         multichannel: Boolean for whether to create a single multi-channel TIFF,
             or a folder of single-channel TIFFs. Defaults to True; if False,
             the sed and optical options are ignored.
-        dtype: Forces the image data saved as either float or uint16. Can
-            specify or ``np.float32`` to force data to be saved as floating
-            point values or ``np.uint16`` to save as unsigned 16-bit integer
-            values. Defaults to None, which saves data as its original type, if
-            the original type can converted without a loss of data.
+        dtype: dtype: One of (``np.float32``, ``np.uint16``) to force the dtype
+            of the saved image data. Defaults to ``None``, which chooses the
+            format based on the data's input type, and will convert to
+            ``np.float32`` or ``np.uint16`` from other float or int types,
+            respectively, if it can do so without a loss of data.
         write_float: Deprecated, will raise ValueError if specified. To
             specify the dtype of the saved image, please use the `dtype`
             argument instead.
@@ -76,10 +76,11 @@ def write(filename, image, sed=None, optical=None, ranges=None,
     Raises:
         ValueError: Raised if
 
-            * The image is not a :class:`mibidata.mibi_image.MibiImage` instance
+            * The image is not a :class:`mibidata.mibi_image.MibiImage`
+              instance.
             * The :class:`mibidata.mibi_image.MibiImage` coordinates, size,
-              masses or targets are None
-            * `dtype` is not one of ``np.float32`` or ``np.uint16``
+              masses or targets are None.
+            * `dtype` is not one of ``np.float32`` or ``np.uint16``.
             * `write_float` has been specified.
             * Converting the native :class:`mibidata.mibi_image.MibiImage` dtype
               to the specified or inferred ``dtype`` results in a loss of data.

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -117,8 +117,7 @@ def write(filename, image, sed=None, optical=None, ranges=None,
                          f'{image.data.dtype} to {save_dtype}')
 
     if ranges is None:
-        dtype_conversion = int if range_dtype == 'I' else float
-        ranges = [(0, dtype_conversion(m)) for m in image.data.max(axis=(0, 1))]
+        ranges = [(0, m) for m in to_save.max(axis=(0, 1))]
 
     coordinates = [
         (286, '2i', 1, _micron_to_cm(image.coordinates[0])),  # x-position

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -65,11 +65,10 @@ def write(filename, image, sed=None, optical=None, ranges=None,
             or a folder of single-channel TIFFs. Defaults to True; if False,
             the sed and optical options are ignored.
         dtype: Forces the image data saved as either float or uint16. Can
-            specify ``'float'`` or ``np.float32`` to force data to be saved as
-            floating point values or ``'uint16'`` or ``np.uint16`` to save as
-            unsigned 16-bit integer values. Defaults to None, which saves data
-            as its original type. Note that forcing native float image data to
-            uint16 could result in a loss of precision as values are clipped.
+            specify or ``np.float32`` to force data to be saved as floating
+            point values or ``np.uint16`` to save as unsigned 16-bit integer
+            values. Defaults to None, which saves data as its original type, if
+            the original type can converted without a loss of data.
         write_float: Deprecated, will raise ValueError if specified. To
             specify the dtype of the saved image, please use the `dtype`
             argument instead.
@@ -80,9 +79,10 @@ def write(filename, image, sed=None, optical=None, ranges=None,
             * The image is not a :class:`mibidata.mibi_image.MibiImage` instance
             * The :class:`mibidata.mibi_image.MibiImage` ccoordinates, size,
               masses or targets are None
-            * `dtype` is not one of ``'float'``, ``'uint16'``, ``np.float32``,
-              or ``np.uint16``
+            * `dtype` is not one of ``np.float32`` or ``np.uint16``
             * `write_float` has been specified.
+            * Converting the native :class:`mibidata.mibi_image.MibiImage` dtype
+              to the specified or inferred ``dtype`` results in a loss of data.
     """
     if not isinstance(image, mi.MibiImage):
         raise ValueError('image must be a mibidata.mibi_image.MibiImage '
@@ -94,13 +94,13 @@ def write(filename, image, sed=None, optical=None, ranges=None,
     if write_float:
         raise ValueError('`write_float` has been deprecated. Please use the '
                          '`dtype` argument instead.')
-    if dtype and not dtype in ['float', 'uint16', np.float32, np.uint16]:
+    if dtype and not dtype in [np.float32, np.uint16]:
         raise ValueError('Invalid dtype specification.')
 
-    if dtype in ['float', np.float32]:
+    if dtype == np.float32:
         save_dtype = np.float32
         range_dtype = 'd'
-    elif dtype in ['uint16', np.uint16]:
+    elif dtype == np.uint16:
         save_dtype = np.uint16
         range_dtype = 'I'
     elif np.issubdtype(image.data.dtype, np.floating):

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -77,7 +77,7 @@ def write(filename, image, sed=None, optical=None, ranges=None,
         ValueError: Raised if
 
             * The image is not a :class:`mibidata.mibi_image.MibiImage` instance
-            * The :class:`mibidata.mibi_image.MibiImage` ccoordinates, size,
+            * The :class:`mibidata.mibi_image.MibiImage` coordinates, size,
               masses or targets are None
             * `dtype` is not one of ``np.float32`` or ``np.uint16``
             * `write_float` has been specified.


### PR DESCRIPTION
Part 1 of this ticket is to have the TIFF writer by default save the underlying dtype unless specified otherwise.