### PR TITLE
TRKR-732 Allow old aperture formats so can still load pre-existing data.

### DIFF
--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -237,6 +237,10 @@ class MibiImage():
     def aperture(self, value):
         if value is not None and value not in APERTURE_MAP.values():
             try:
+                print(value, {
+                    **_DEPRECATED_APERTURE_MAP,
+                    **APERTURE_MAP
+                })
                 self._aperture = {
                     **_DEPRECATED_APERTURE_MAP,
                     **APERTURE_MAP
@@ -248,12 +252,11 @@ class MibiImage():
                                           _DEPRECATED_APERTURE_MAP[value],
                                           APERTURE_MAP)
                 )
-            except ValueError:
+            except KeyError:
                 raise ValueError(
                     'Invalid aperture code \'{}\', must use values'
                     'from the following map: {}'.format(value, APERTURE_MAP)
                 )
-        self._aperture = value
 
     @property
     def channels(self):

--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -34,6 +34,13 @@ APERTURE_MAP = {
     u'30 \u03BCm': APERTURE_30UM,
 }
 
+_DEPRECATED_APERTURE_MAP = {
+    '1mm': APERTURE_1MM,
+    '300um': APERTURE_300UM,
+    '100um': APERTURE_100UM,
+    '30um': APERTURE_30UM,
+}
+
 class MibiImage():
     """A multiplexed image with labeled channels and metadata.
 
@@ -229,10 +236,20 @@ class MibiImage():
     @aperture.setter
     def aperture(self, value):
         if value is not None and value not in APERTURE_MAP.values():
-            raise ValueError(
-                'Invalid aperture code \'{}\', must use values'
-                'from the following map: {}'.format(value, APERTURE_MAP)
-            )
+            if value in _DEPRECATED_APERTURE_MAP:
+                warnings.warn(
+                    'Deprecated aperture code \'{}\', converting to \'{}\'. In '
+                    'a future version, values from the following map will be '
+                    'required: {}'.format(value,
+                                          _DEPRECATED_APERTURE_MAP[value],
+                                          APERTURE_MAP)
+                )
+                value = _DEPRECATED_APERTURE_MAP[value]
+            else:
+                raise ValueError(
+                    'Invalid aperture code \'{}\', must use values'
+                    'from the following map: {}'.format(value, APERTURE_MAP)
+                )
         self._aperture = value
 
     @property

--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -237,10 +237,6 @@ class MibiImage():
     def aperture(self, value):
         if value is not None and value not in APERTURE_MAP.values():
             try:
-                print(value, {
-                    **_DEPRECATED_APERTURE_MAP,
-                    **APERTURE_MAP
-                })
                 self._aperture = {
                     **_DEPRECATED_APERTURE_MAP,
                     **APERTURE_MAP

--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -237,7 +237,10 @@ class MibiImage():
     def aperture(self, value):
         if value is not None and value not in APERTURE_MAP.values():
             try:
-                self._aperture = {**_DEPRECATED_APERTURE_MAP, **APERTURE_MAP}[value]
+                self._aperture = {
+                    **_DEPRECATED_APERTURE_MAP,
+                    **APERTURE_MAP
+                }[value]
                 warnings.warn(
                     'Deprecated aperture code \'{}\', converting to \'{}\'. In '
                     'a future version, values from the following map will be '

--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -237,7 +237,7 @@ class MibiImage():
     def aperture(self, value):
         if value in APERTURE_MAP.values() or value is None:
             # Allow valid aperture codes or None
-            self._aperture = value;
+            self._aperture = value
         else:
             # Convert known string aperture parameters, if possible
             try:

--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -236,7 +236,8 @@ class MibiImage():
     @aperture.setter
     def aperture(self, value):
         if value is not None and value not in APERTURE_MAP.values():
-            if value in _DEPRECATED_APERTURE_MAP:
+            try:
+                self._aperture = {**_DEPRECATED_APERTURE_MAP, **APERTURE_MAP}[value]
                 warnings.warn(
                     'Deprecated aperture code \'{}\', converting to \'{}\'. In '
                     'a future version, values from the following map will be '
@@ -244,8 +245,7 @@ class MibiImage():
                                           _DEPRECATED_APERTURE_MAP[value],
                                           APERTURE_MAP)
                 )
-                value = _DEPRECATED_APERTURE_MAP[value]
-            else:
+            except ValueError:
                 raise ValueError(
                     'Invalid aperture code \'{}\', must use values'
                     'from the following map: {}'.format(value, APERTURE_MAP)

--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -235,7 +235,11 @@ class MibiImage():
 
     @aperture.setter
     def aperture(self, value):
-        if value is not None and value not in APERTURE_MAP.values():
+        if value in APERTURE_MAP.values() or value is None:
+            # Allow valid aperture codes or None
+            self._aperture = value;
+        else:
+            # Convert known string aperture parameters, if possible
             try:
                 self._aperture = {
                     **_DEPRECATED_APERTURE_MAP,

--- a/mibidata/tests/test_mibi_image.py
+++ b/mibidata/tests/test_mibi_image.py
@@ -138,6 +138,18 @@ class TestMibiImage(unittest.TestCase):
         self.assertEqual(image.fov_id, 'Point1')
         self.assertEqual(image.folder, 'Point1/RowNumber0/Depth_Profile0')
 
+    def test_convert_from_deprecated_aperture(self):
+        with warnings.catch_warnings(record=True) as w:
+            image = mi.MibiImage(TEST_DATA, TUPLE_LABELS,
+                                 aperture='300um')
+        self.assertTrue(
+            str(w[-1].message).startswith('Deprecated aperture code'))
+        self.assertEqual(image.aperture, 'B')
+
+    def test_bad_aperture(self):
+        with self.assertRaises(ValueError):
+            mi.MibiImage(TEST_DATA, TUPLE_LABELS, aperture='invalid')
+
     def test_equality(self):
         first = mi.MibiImage(TEST_DATA, STRING_LABELS)
         second = mi.MibiImage(TEST_DATA.copy(), STRING_LABELS)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 setup(name='mibitracker-client',
       author='IONpath, Inc.',
       author_email='mibitracker-support@ionpath.com',
-      version='1.2.0',
+      version='1.2.3',
       url='https://github.com/ionpath/mibitracker-client',
       description='Python utilities for IONpath MIBItracker and MIBItiff data',
       license='GNU General Public License v3.0',


### PR DESCRIPTION
I did an inventory of existing data and this should cover making sure we can still load it with the newest tiff reader.