### PR TITLE
DPPA-645: Check required metadata fields when saving MIBItiff

### DIFF
--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -94,15 +94,16 @@ def write(filename, image, sed=None, optical=None, ranges=None,
         raise ValueError('image must be a mibidata.mibi_image.MibiImage '
                          'instance.')
     missing_required_metadata = [m for m in REQUIRED_METADATA_ATTRIBUTES
-                                 if not getattr(image, meta_attr)]
+                                 if not getattr(image, m)]
     if missing_required_metadata:
         if len(missing_required_metadata) == 1:
             missing_metadata_error = (f'{missing_required_metadata[0]} is '
                                       f'required and may not be None.')
-        else:    
-            missing_metadata_error = (f'{', '.join(missing_required_metadata)}'
+        else:
+            missing_metadata_error = (f'{", ".join(missing_required_metadata)}'
                                       f' are required and may not be None.')
         raise ValueError(missing_metadata_error)
+
     if write_float is not None:
         raise ValueError('`write_float` has been deprecated. Please use the '
                          '`dtype` argument instead.')

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -31,9 +31,9 @@ _MAX_DENOMINATOR = 1000000
 # Encoding of tiff tags.
 ENCODING = 'utf-8'
 
-REQUIRED_METADATA_ATTRIBUTES = ('fov_id', 'fov_name', 'run', 'folder',
-                                'dwell', 'scans', 'mass_gain', 'mass_offset',
-                                'time_resolution', 'coordinates')
+REQUIRED_METADATA_ATTRIBUTES = ('fov_id', 'fov_name', 'run', 'folder', 'dwell',
+                                'scans', 'mass_gain', 'mass_offset', 'time_resolution',
+                                'coordinates', 'size', 'masses', 'targets')
 
 def _micron_to_cm(arg):
     """Converts microns (1cm = 1e4 microns) to a fraction tuple in cm."""
@@ -92,28 +92,22 @@ def write(filename, image, sed=None, optical=None, ranges=None,
     if not isinstance(image, mi.MibiImage):
         raise ValueError('image must be a mibidata.mibi_image.MibiImage '
                          'instance.')
-    if image.coordinates is None or image.size is None:
-        raise ValueError('Image coordinates and size must not be None.')
-    if image.fov_id is None:
-        raise ValueError('Image fov_id must not be None.')
-    if image.fov_name is None:
-        raise ValueError('Image name must not be None.')
-    if image.run is None:
-        raise ValueError('Image run must not be None.')
-    if image.folder is None:
-        raise ValueError('Image folder must not be None.')
-    if image.dwell is None:
-        raise ValueError('Image dwell must not be None.')
-    if image.scans is None:
-        raise ValueError('Image scans must not be None.')
-    if image.mass_gain is None:
-        raise ValueError('Image mass_gain must not be None.')
-    if image.mass_offset is None:
-        raise ValueError('Image mass_offset must not be None.')
-    if image.time_resolution is None:
-        raise ValueError('Image time_resolution must not be None.')
-    if image.masses is None or image.targets is None:
-        raise ValueError('Image channels must contain both masses and targets.')
+    missing_required_metadata = []
+    for meta_attr in REQUIRED_METADATA_ATTRIBUTES:
+        if getattr(image, meta_attr) is None:
+            missing_required_metadata.append(meta_attr)
+    if len(missing_required_metadata) > 0:
+        if len(missing_required_metadata) == 1:
+            raise ValueError(missing_required_metadata[0] + ' is required and may not be None.')
+        else:
+            missing_fields = ''
+            for i, meta_attr in enumerate(missing_required_metadata):
+                if i == len(missing_required_metadata) - 1:
+                    missing_fields += meta_attr + ' '
+                else:
+                    missing_fields += meta_attr + ', '
+            raise ValueError(missing_fields + 'are required and may not be None.')
+    
     if write_float is not None:
         raise ValueError('`write_float` has been deprecated. Please use the '
                          '`dtype` argument instead.')

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -31,7 +31,7 @@ _MAX_DENOMINATOR = 1000000
 # Encoding of tiff tags.
 ENCODING = 'utf-8'
 
-REQUIRED_METADATA_ATTRIBUTES = ('fov_id', 'fov_name', 'run', 'folder', 
+REQUIRED_METADATA_ATTRIBUTES = ('fov_id', 'fov_name', 'run', 'folder',
                                 'dwell', 'scans', 'mass_gain', 'mass_offset',
                                 'time_resolution', 'coordinates')
 

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -31,9 +31,10 @@ _MAX_DENOMINATOR = 1000000
 # Encoding of tiff tags.
 ENCODING = 'utf-8'
 
-REQUIRED_METADATA_ATTRIBUTES = ('fov_id', 'fov_name', 'run', 'folder', 'dwell',
-                                'scans', 'mass_gain', 'mass_offset', 'time_resolution',
-                                'coordinates', 'size', 'masses', 'targets')
+REQUIRED_METADATA_ATTRIBUTES = ('fov_id', 'fov_name', 'run', 'folder',
+                                'dwell', 'scans', 'mass_gain', 'mass_offset',
+                                'time_resolution', 'coordinates', 'size', 
+                                'masses', 'targets')
 
 def _micron_to_cm(arg):
     """Converts microns (1cm = 1e4 microns) to a fraction tuple in cm."""
@@ -96,18 +97,20 @@ def write(filename, image, sed=None, optical=None, ranges=None,
     for meta_attr in REQUIRED_METADATA_ATTRIBUTES:
         if getattr(image, meta_attr) is None:
             missing_required_metadata.append(meta_attr)
-    if len(missing_required_metadata) > 0:
+    if missing_required_metadata:
         if len(missing_required_metadata) == 1:
-            raise ValueError(missing_required_metadata[0] + ' is required and may not be None.')
+            missing_metadata_error = f'{missing_required_metadata[0]} is '
+                                     f'required and may not be None.'
         else:
             missing_fields = ''
             for i, meta_attr in enumerate(missing_required_metadata):
                 if i == len(missing_required_metadata) - 1:
-                    missing_fields += meta_attr + ' '
+                    missing_fields += f'{meta_attr} '
                 else:
-                    missing_fields += meta_attr + ', '
-            raise ValueError(missing_fields + 'are required and may not be None.')
-    
+                    missing_fields += f'{meta_attr}, '
+            missing_metadata_error = f'{missing_fields} are required'
+                                     f' and may not be None.'
+        raise ValueError(missing_metadata_error)
     if write_float is not None:
         raise ValueError('`write_float` has been deprecated. Please use the '
                          '`dtype` argument instead.')

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -99,8 +99,8 @@ def write(filename, image, sed=None, optical=None, ranges=None,
             missing_required_metadata.append(meta_attr)
     if missing_required_metadata:
         if len(missing_required_metadata) == 1:
-            missing_metadata_error = f'{missing_required_metadata[0]} is '
-                                     f'required and may not be None.'
+            missing_metadata_error = (f'{missing_required_metadata[0]} is '
+                                      f'required and may not be None.')
         else:
             missing_fields = ''
             for i, meta_attr in enumerate(missing_required_metadata):
@@ -108,8 +108,8 @@ def write(filename, image, sed=None, optical=None, ranges=None,
                     missing_fields += f'{meta_attr} '
                 else:
                     missing_fields += f'{meta_attr}, '
-            missing_metadata_error = f'{missing_fields} are required'
-                                     f' and may not be None.'
+            missing_metadata_error = (f'{missing_fields} are required'
+                                      f' and may not be None.')
         raise ValueError(missing_metadata_error)
     if write_float is not None:
         raise ValueError('`write_float` has been deprecated. Please use the '

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -99,7 +99,7 @@ def write(filename, image, sed=None, optical=None, ranges=None,
     if image.fov_name is None:
         raise ValueError('Image name must not be None.')
     if image.run is None:
-        raise ValueError('Image run must not be None'.)
+        raise ValueError('Image run must not be None.')
     if image.folder is None:
         raise ValueError('Image folder must not be None.')
     if image.dwell is None:

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -31,6 +31,9 @@ _MAX_DENOMINATOR = 1000000
 # Encoding of tiff tags.
 ENCODING = 'utf-8'
 
+REQUIRED_METADATA_ATTRIBUTES = ('fov_id', 'fov_name', 'run', 'folder', 
+                                'dwell', 'scans', 'mass_gain', 'mass_offset',
+                                'time_resolution', 'coordinates')
 
 def _micron_to_cm(arg):
     """Converts microns (1cm = 1e4 microns) to a fraction tuple in cm."""
@@ -79,7 +82,8 @@ def write(filename, image, sed=None, optical=None, ranges=None,
             * The image is not a :class:`mibidata.mibi_image.MibiImage`
               instance.
             * The :class:`mibidata.mibi_image.MibiImage` coordinates, size,
-              masses or targets are None.
+              fov_id, fov_name, run, folder, dwell, scans, mass_gain,
+              mass_offset, time_resolution, masses or targets are None.
             * `dtype` is not one of ``np.float32`` or ``np.uint16``.
             * `write_float` has been specified.
             * Converting the native :class:`mibidata.mibi_image.MibiImage` dtype
@@ -90,6 +94,24 @@ def write(filename, image, sed=None, optical=None, ranges=None,
                          'instance.')
     if image.coordinates is None or image.size is None:
         raise ValueError('Image coordinates and size must not be None.')
+    if image.fov_id is None:
+        raise ValueError('Image fov_id must not be None.')
+    if image.fov_name is None:
+        raise ValueError('Image name must not be None.')
+    if image.run is None:
+        raise ValueError('Image run must not be None'.)
+    if image.folder is None:
+        raise ValueError('Image folder must not be None.')
+    if image.dwell is None:
+        raise ValueError('Image dwell must not be None.')
+    if image.scans is None:
+        raise ValueError('Image scans must not be None.')
+    if image.mass_gain is None:
+        raise ValueError('Image mass_gain must not be None.')
+    if image.mass_offset is None:
+        raise ValueError('Image mass_offset must not be None.')
+    if image.time_resolution is None:
+        raise ValueError('Image time_resolution must not be None.')
     if image.masses is None or image.targets is None:
         raise ValueError('Image channels must contain both masses and targets.')
     if write_float is not None:

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -33,7 +33,7 @@ ENCODING = 'utf-8'
 
 REQUIRED_METADATA_ATTRIBUTES = ('fov_id', 'fov_name', 'run', 'folder',
                                 'dwell', 'scans', 'mass_gain', 'mass_offset',
-                                'time_resolution', 'coordinates', 'size', 
+                                'time_resolution', 'coordinates', 'size',
                                 'masses', 'targets')
 
 def _micron_to_cm(arg):
@@ -93,23 +93,15 @@ def write(filename, image, sed=None, optical=None, ranges=None,
     if not isinstance(image, mi.MibiImage):
         raise ValueError('image must be a mibidata.mibi_image.MibiImage '
                          'instance.')
-    missing_required_metadata = []
-    for meta_attr in REQUIRED_METADATA_ATTRIBUTES:
-        if getattr(image, meta_attr) is None:
-            missing_required_metadata.append(meta_attr)
+    missing_required_metadata = [m for m in REQUIRED_METADATA_ATTRIBUTES
+                                 if not getattr(image, meta_attr)]
     if missing_required_metadata:
         if len(missing_required_metadata) == 1:
             missing_metadata_error = (f'{missing_required_metadata[0]} is '
                                       f'required and may not be None.')
-        else:
-            missing_fields = ''
-            for i, meta_attr in enumerate(missing_required_metadata):
-                if i == len(missing_required_metadata) - 1:
-                    missing_fields += f'{meta_attr} '
-                else:
-                    missing_fields += f'{meta_attr}, '
-            missing_metadata_error = (f'{missing_fields} are required'
-                                      f' and may not be None.')
+        else:    
+            missing_metadata_error = (f'{', '.join(missing_required_metadata)}'
+                                      f' are required and may not be None.')
         raise ValueError(missing_metadata_error)
     if write_float is not None:
         raise ValueError('`write_float` has been deprecated. Please use the '


### PR DESCRIPTION
This pull request is for changes to tiff.py in the mibitracker-client repo. The write() function now raises errors if fov_id, fov_name, run, folder, dwell, scans, mass_gain, mass_offset, or time_resolution metadata fields are missing (in addition to coordinates and size which already raised errors). 

I do have a couple quick questions indirectly related to this ticket: 

- In write(), an error is raised if the image.targets metadata field is left blank, but the MIBItiff Specifications google doc says that this field is optional. Should this be changed in write()?

- If tiff.py the metadata is for the channel is named image.masses and image.targets, but in the google doc it denotes them as channel.mass and channel.target? Should the names in the doc be plural to match the actual names in the code? (this could not even be referring to same attributes/it is super trivial but just thought I would ask)
