### PR TITLE
DPPA-579: Avoid repetition between tiff.info and tiff.read

### DIFF
--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -205,14 +205,8 @@ class MibiImage():
     def folder(self, value):
         """Enforce consistency with fov_id."""
         if value:
-            fov = value.split('/')[0]
-            if not self.fov_id:
-                self._fov_id = fov
-            elif self.fov_id != fov:
-                raise ValueError('fov_id must match folder, but here '
-                                 'fov_id={} and you are trying to set folder '
-                                 'to {}.'.format(self.fov_id, value))
             self._folder = value
+            self.match_fov_folder(value, self._fov_id, 'folder', 'fov_id')
 
     @property
     def fov_id(self):
@@ -221,13 +215,8 @@ class MibiImage():
     @fov_id.setter
     def fov_id(self, value):
         """Enforce consistency with folder."""
-        if not self.folder:
-            self._folder = value
-        elif value != self.folder.split('/')[0]:
-            raise ValueError('fov_id must match folder, but here '
-                             'folder={} and you are trying to set fov_id '
-                             'to {}.'.format(self.folder, value))
         self._fov_id = value
+        self.match_fov_folder(value, self._folder, 'fov_id', 'folder')
 
     @property
     def aperture(self):
@@ -341,6 +330,28 @@ class MibiImage():
                     'from the following map: {}'.format(value, APERTURE_MAP)
                 )
         return aperture
+
+
+    @staticmethod
+    def match_fov_folder(value, field, value_name, field_name):
+    """Enforces consistency between fov_id and folder.
+
+    Args:
+        value: Value to match with.
+        field: Field that needs to be updated to value.
+        value_name: String representing whether matching folder or fov_id field.
+        field_name: String representing whether updating folder or fov_id field.
+    """
+        if field_name == 'fov_id':
+            value = value.split('/')[0]
+        if not field:
+            warnings.warn('The "{field_name}" attribute is required if "{value_name}" is specified. '
+                      'Setting "{field_name}" to {value}.')
+        elif field != value:
+            warnings.warn(
+            'The attribute "{field_name}" must match "{value_name}". '
+            'Changing "{field_name}" from {} to {}.'.format(field, value))
+        field = value
 
     def metadata(self):
         """Returns a dictionary of the image's metadata."""

--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -334,23 +334,26 @@ class MibiImage():
 
     @staticmethod
     def match_fov_folder(value, field, value_name, field_name):
-    """Enforces consistency between fov_id and folder.
+        """Enforces consistency between fov_id and folder.
 
-    Args:
-        value: Value to match with.
-        field: Field that needs to be updated to value.
-        value_name: String representing whether matching folder or fov_id field.
-        field_name: String representing whether updating folder or fov_id field.
-    """
+        Args:
+            value: Value to match with.
+            field: Field that needs to be updated to value.
+            value_name: String representing whether matching folder
+                        or fov_id field.
+            field_name: String representing whether updating folder
+                        or fov_id field.
+        """
         if field_name == 'fov_id':
             value = value.split('/')[0]
         if not field:
-            warnings.warn('The "{field_name}" attribute is required if "{value_name}" is specified. '
-                      'Setting "{field_name}" to {value}.')
+            warnings.warn(
+                f'The "{field_name}" attribute is required if "{value_name}" '
+                f'is specified. Setting "{field_name}" to {value}.')
         elif field != value:
             warnings.warn(
-            'The attribute "{field_name}" must match "{value_name}". '
-            'Changing "{field_name}" from {} to {}.'.format(field, value))
+                f'The attribute "{field_name}" must match "{value_name}". '
+                f'Changing "{field_name}" from {field} to {value}.')
         field = value
 
     def metadata(self):

--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -206,7 +206,8 @@ class MibiImage():
         """Enforce consistency with fov_id."""
         if value:
             self._folder = value
-            self._fov_id = self.match_fov_folder(value, self._fov_id, 'folder', 'fov_id')
+            self._fov_id = self.match_fov_folder(value, self._fov_id, 'folder',
+                                                 'fov_id')
 
     @property
     def fov_id(self):
@@ -216,7 +217,8 @@ class MibiImage():
     def fov_id(self, value):
         """Enforce consistency with folder."""
         self._fov_id = value
-        self._folder = self.match_fov_folder(value, self._folder, 'fov_id', 'folder')
+        self._folder = self.match_fov_folder(value, self._folder, 'fov_id',
+                                             'folder')
 
     @property
     def aperture(self):
@@ -333,7 +335,8 @@ class MibiImage():
 
 
     @staticmethod
-    def match_fov_folder(value, field, value_name='valuename', field_name='fieldname'):
+    def match_fov_folder(value, field, value_name='valuename',
+                         field_name='fieldname'):
         """Enforces consistency between fov_id and folder.
 
         Args:

--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -335,8 +335,8 @@ class MibiImage():
 
 
     @staticmethod
-    def match_fov_folder(value, field, value_name='valuename',
-                         field_name='fieldname'):
+    def match_fov_folder(value, field, value_name,
+                         field_name):
         """Enforces consistency between fov_id and folder.
 
         Args:

--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -206,7 +206,7 @@ class MibiImage():
         """Enforce consistency with fov_id."""
         if value:
             self._folder = value
-            self.match_fov_folder(value, self._fov_id, 'folder', 'fov_id')
+            self._fov_id = self.match_fov_folder(value, self._fov_id, 'folder', 'fov_id')
 
     @property
     def fov_id(self):
@@ -216,7 +216,7 @@ class MibiImage():
     def fov_id(self, value):
         """Enforce consistency with folder."""
         self._fov_id = value
-        self.match_fov_folder(value, self._folder, 'fov_id', 'folder')
+        self._folder = self.match_fov_folder(value, self._folder, 'fov_id', 'folder')
 
     @property
     def aperture(self):
@@ -333,7 +333,7 @@ class MibiImage():
 
 
     @staticmethod
-    def match_fov_folder(value, field, value_name, field_name):
+    def match_fov_folder(value, field, value_name='valuename', field_name='fieldname'):
         """Enforces consistency between fov_id and folder.
 
         Args:
@@ -343,8 +343,10 @@ class MibiImage():
                         or fov_id field.
             field_name: String representing whether updating folder
                         or fov_id field.
+        Returns:
+            value: Value to set field to.
         """
-        if field_name == 'fov_id':
+        if field_name == 'fov_id' and value_name == 'folder':
             value = value.split('/')[0]
         if not field:
             warnings.warn(
@@ -354,7 +356,7 @@ class MibiImage():
             warnings.warn(
                 f'The attribute "{field_name}" must match "{value_name}". '
                 f'Changing "{field_name}" from {field} to {value}.')
-        field = value
+        return value
 
     def metadata(self):
         """Returns a dictionary of the image's metadata."""

--- a/mibidata/tests/test_mibi_image.py
+++ b/mibidata/tests/test_mibi_image.py
@@ -122,9 +122,9 @@ class TestMibiImage(unittest.TestCase):
         image.fov_id = 'Point2'
         image.folder = 'Point2/RowNumber0/Depth_Profile0'
         image.fov_name = 'R1C3_Tonsil'
-        with self.assertRaises(ValueError):
+        with self.assertWarns(UserWarning):
             image.fov_id = 'Point99'
-        with self.assertRaises(ValueError):
+        with self.assertWarns(UserWarning):
             image.fov_id = None
 
     def test_check_fov_id_without_folder(self):
@@ -223,7 +223,7 @@ class TestMibiImage(unittest.TestCase):
         metadata = METADATA.copy()
         metadata = {**metadata, **USER_DEFINED_METADATA}
         metadata['fov_id'] = 'Point99'
-        with self.assertRaises(ValueError):
+        with self.assertWarns(UserWarning):
             mi.MibiImage(TEST_DATA, TUPLE_LABELS, **metadata)
 
     def test_channel_inds_single_channel(self):

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -342,19 +342,15 @@ def _convert_from_previous(description):
     if not description.get('mibi.fov_name') and description.get(
             'mibi.description'):
         description['mibi.fov_name'] = description.pop('mibi.description')
-    # TODO: Clean up repetition between this and the same MibiImage method
-    if description.get('mibi.folder') and not description.get('mibi.fov_id'):
-        description['mibi.fov_id'] = description['mibi.folder'].split('/')[0]
-        warnings.warn(
-            'The "fov_id" attribute is now required if "folder" is '
-            'specified. Setting "fov_id" to {}.'.format(
-                description['mibi.fov_id']))
-    if (not description.get('mibi.folder') and description.get('mibi.fov_id')
-            and description.get('mibi.fov_id').startswith('FOV')):
-        description['mibi.folder'] = description['mibi.fov_id']
-        warnings.warn(
-            'The "folder" attribute is required if "fov_id" is specified. '
-            'Setting "folder" to {}.'.format(description['mibi.folder']))
+    if description.get('mibi.folder'):
+        description['mibi.fov_id'] = ''
+        value = 'mibi.folder'
+        field = 'mibi.fov_id'
+    if description.get('mibi.fov_id'):
+        description['mibi.folder'] = ''
+        value = 'mibi.fov_id'
+        field = 'mibi.folder'
+    mi.MibiImage.match_fov_folder(description[value], description[field], value[5:], field[5:])
     if description.get('mibi.aperture'):
         description['mibi.aperture'] = mi.MibiImage.parse_aperture(
             description['mibi.aperture'])
@@ -375,7 +371,7 @@ def _get_page_data(page, description, metadata, channels):
         metadata.update(_page_metadata(page, description))
 
 def info(filename):
-    """Gets the SIMS pages' metadata from a MibiTiff file.
+    """Gets the metadata from a MibiTiff file.
 
     Args:
         filename: The path to the TIFF.

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -346,11 +346,15 @@ def _convert_from_previous(description):
         description['mibi.fov_id'] = ''
         value = 'mibi.folder'
         field = 'mibi.fov_id'
+        matchNeeded = True
     if description.get('mibi.fov_id'):
         description['mibi.folder'] = ''
         value = 'mibi.fov_id'
         field = 'mibi.folder'
-    mi.MibiImage.match_fov_folder(description[value], description[field], value[5:], field[5:])
+        matchNeeded = True
+    if matchNeeded:
+        mi.MibiImage.match_fov_folder(description[value], description[field],
+                                      value[5:], field[5:])
     if description.get('mibi.aperture'):
         description['mibi.aperture'] = mi.MibiImage.parse_aperture(
             description['mibi.aperture'])

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -353,8 +353,8 @@ def _convert_from_previous(description):
         field = 'mibi.folder'
         matchNeeded = True
     if matchNeeded:
-        mi.MibiImage.match_fov_folder(description[value], description[field],
-                                      value[5:], field[5:])
+        description[field] = mi.MibiImage.match_fov_folder(description[value],
+                                description[field], value[5:], field[5:])
     if description.get('mibi.aperture'):
         description['mibi.aperture'] = mi.MibiImage.parse_aperture(
             description['mibi.aperture'])

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -346,19 +346,16 @@ def _convert_from_previous(description):
         description['mibi.fov_id'] = ''
         value = 'mibi.folder'
         field = 'mibi.fov_id'
-        value_name = 'folder'
-        field_name = 'fov_id'
         matchNeeded = True
     if description.get('mibi.fov_id'):
         description['mibi.folder'] = ''
         value = 'mibi.fov_id'
         field = 'mibi.folder'
-        value_name = 'fov_id'
-        field_name = 'folder'
         matchNeeded = True
     if matchNeeded:
         description[field] = mi.MibiImage.match_fov_folder(
-            description[value], description[field], value_name, field_name)
+            description[value], description[field], value.split('.')[1],
+            field.split('.')[1])
     if description.get('mibi.aperture'):
         description['mibi.aperture'] = mi.MibiImage.parse_aperture(
             description['mibi.aperture'])

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -346,15 +346,19 @@ def _convert_from_previous(description):
         description['mibi.fov_id'] = ''
         value = 'mibi.folder'
         field = 'mibi.fov_id'
+        value_name = 'folder'
+        field_name = 'fov_id'
         matchNeeded = True
     if description.get('mibi.fov_id'):
         description['mibi.folder'] = ''
         value = 'mibi.fov_id'
         field = 'mibi.folder'
+        value_name = 'fov_id'
+        field_name = 'folder'
         matchNeeded = True
     if matchNeeded:
-        description[field] = mi.MibiImage.match_fov_folder(description[value],
-                                description[field], value[5:], field[5:])
+        description[field] = mi.MibiImage.match_fov_folder(
+            description[value], description[field], value_name, field_name)
     if description.get('mibi.aperture'):
         description['mibi.aperture'] = mi.MibiImage.parse_aperture(
             description['mibi.aperture'])

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -339,6 +339,7 @@ def _convert_from_previous(description):
     Most of these conversions would happen during MibiImage construction,
     but we do them here in case reading the info only.
     """
+    match_needed = False
     if not description.get('mibi.fov_name') and description.get(
             'mibi.description'):
         description['mibi.fov_name'] = description.pop('mibi.description')
@@ -346,13 +347,13 @@ def _convert_from_previous(description):
         description['mibi.fov_id'] = ''
         value = 'mibi.folder'
         field = 'mibi.fov_id'
-        matchNeeded = True
+        match_needed = True
     if description.get('mibi.fov_id'):
         description['mibi.folder'] = ''
         value = 'mibi.fov_id'
         field = 'mibi.folder'
-        matchNeeded = True
-    if matchNeeded:
+        match_needed = True
+    if match_needed:
         description[field] = mi.MibiImage.match_fov_folder(
             description[value], description[field], value.split('.')[1],
             field.split('.')[1])


### PR DESCRIPTION
Added very lightweight wrapper function for 2 main lines of shared code between the tiff.info and tiff.read called _get_page data() which updates the metadata for the tiff and list of channels.

Updated helper function _get_description() to return the image type as well as description to minimize redundancy