### PR TITLE
DPPA 578: Add methods to allow the user to add optional metadata attributes to MibiImage

### DIFF
--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -225,11 +225,11 @@ class MibiImage():
             else:
                 _no_attr.append(attr)
         if _required_rem:
-            raise ValueError(f'{", ".join(_required_rem)} are required and '
-                             f'cannot be removed.')
+            warnings.warn(f'{", ".join(_required_rem)} are required and '
+                          f'were not removed.')
         if _no_attr:
-            raise ValueError(f'{", ".join(_no_attr)} are not attributes of '
-                             f'this instance.')
+            warnings.warn(f'{", ".join(_no_attr)} are not attributes of '
+                          f'this instance.')
 
 
     @property

--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -222,11 +222,12 @@ class MibiImage():
                 setattr(self, attr, None)
             elif hasattr(self, attr):
                 delattr(self, attr)
+                self._user_defined_attributes.remove(attr)
             else:
                 _no_attr.append(attr)
         if _required_rem:
             warnings.warn(f'{", ".join(_required_rem)} are required and '
-                          f'were not removed.')
+                          f'were not removed. Attributes were set to None.')
         if _no_attr:
             warnings.warn(f'{", ".join(_no_attr)} are not attributes of '
                           f'this instance.')

--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -213,11 +213,12 @@ class MibiImage():
             setattr(self, key, value)
 
 
-    def remove_attr(self, attributes):
+    def remove_attr(self, *args):
         """Removes user-defined attributes from the class instance in use.
 
         Args:
-            attributes: A list of user-defined attributes for deletion.
+            attributes: A single string or a list of user-defined attributes
+                        for deletion.
 
         Raises:
             ValueError: Raised if
@@ -225,16 +226,16 @@ class MibiImage():
                 * attempts to remove a required attribute.
                 * an attribute is not defined for this instance.
         """
-        required_rem = [attr for attr in attributes if attr
+        required_rem = [attr for attr in args if attr
                         in SPECIFIED_METADATA_ATTRIBUTES]
-        no_attr = [attr for attr in attributes if not hasattr(self, attr)]
+        no_attr = [attr for attr in args if not hasattr(self, attr)]
         if required_rem:
             if len(required_rem) == 1:
                 required_error = (f'{required_rem[0]} is a required '
-                                  f'attribute and was not removed.')
+                                  f'attribute.')
             else:
                 required_error = (f'{", ".join(required_rem)} are required '
-                                  f'attributes and were not removed.')
+                                  f'attributes.')
             raise ValueError(required_error)
         if no_attr:
             if len(no_attr) == 1:
@@ -244,7 +245,7 @@ class MibiImage():
                 required_error = (f'{", ".join(no_attr)} are not attributes '
                                   f'of this instance.')
             raise ValueError(required_error)
-        for attr in attributes:
+        for attr in args:
             delattr(self, attr)
             self._user_defined_attributes.remove(attr)
 

--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -199,21 +199,19 @@ class MibiImage():
             defined for this instance.
 
         """
-        already_defined = []
-        for key, value in kwargs.items():
-            if not hasattr(self, key):
-                self._user_defined_attributes.append(key)
-                setattr(self, key, value)
-            else:
-                already_defined.append(key)
+        already_defined = [attr for attr in kwargs if hasattr(self, attr)]
         if already_defined:
             if len(already_defined) == 1:
-                already_defined_error = (f'{already_defined[0]} is '
-                                         f'already defined for this instance.')
+                already_def_error = (f'{already_defined[0]} is already '
+                                     f'an attribute of this instance.')
             else:
-                already_defined_error = (f'{", ".join(already_defined)} are '
-                                         f'already defined for this instance.')
-            raise ValueError(already_defined_error)
+                already_def_error = (f'{", ".join(already_defined)} are '
+                                     f'already attributes for this instance.')
+            raise ValueError(already_def_error)
+        for key, value in kwargs.items():
+            self._user_defined_attributes.append(key)
+            setattr(self, key, value)
+
 
     def remove_attr(self, attributes):
         """Removes user-defined attributes from the class instance in use.
@@ -227,33 +225,28 @@ class MibiImage():
                 * attempts to remove a required attribute.
                 * an attribute is not defined for this instance.
         """
-        _required_attr = SPECIFIED_METADATA_ATTRIBUTES
-        _required_rem = []
-        _no_attr = []
-        for attr in attributes:
-            if attr in _required_attr:
-                _required_rem.append(attr)
-            elif hasattr(self, attr):
-                delattr(self, attr)
-                self._user_defined_attributes.remove(attr)
-            else:
-                _no_attr.append(attr)
-        if _required_rem:
-            if len(_required_rem) == 1:
-                required_error = (f'{_required_rem[0]} is a required '
+        required_rem = [attr for attr in attributes if attr
+                        in SPECIFIED_METADATA_ATTRIBUTES]
+        no_attr = [attr for attr in attributes if not hasattr(self, attr)]
+        if required_rem:
+            if len(required_rem) == 1:
+                required_error = (f'{required_rem[0]} is a required '
                                   f'attribute and was not removed.')
             else:
-                required_error = (f'{", ".join(_required_rem)} are required '
+                required_error = (f'{", ".join(required_rem)} are required '
                                   f'attributes and were not removed.')
             raise ValueError(required_error)
-        if _no_attr:
-            if len(_no_attr) == 1:
-                required_error = (f'{_no_attr[0]} is not an attribute '
+        if no_attr:
+            if len(no_attr) == 1:
+                required_error = (f'{no_attr[0]} is not an attribute '
                                   f'of this instance.')
             else:
-                required_error = (f'{", ".join(_no_attr)} are not attributes '
+                required_error = (f'{", ".join(no_attr)} are not attributes '
                                   f'of this instance.')
             raise ValueError(required_error)
+        for attr in attributes:
+            delattr(self, attr)
+            self._user_defined_attributes.remove(attr)
 
 
     @property

--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -185,6 +185,53 @@ class MibiImage():
             setattr(self, k, v)
             self._user_defined_attributes.append(k)
 
+    def add_attr(self, **kwargs):
+        """Adds metadata key-value pairs as attributes to
+           the class instance in use. If attribute already exists
+           for the current instance, updates value of attribute.
+
+        Args:
+            kwargs: A mapping of arguments for a user to add multiple
+                    attributes with their respecitve
+                    values.
+        """
+        date = kwargs.pop('date', self.date)
+        datetime_format = kwargs.pop('datetime_format', _DATETIME_FORMAT)
+        try:
+            self.date = datetime.datetime.strptime(date, datetime_format)
+        except TypeError:  # Given as datetime obj already, or None.
+            self.date = date
+        for key, value in kwargs.items():
+            if key not in SPECIFIED_METADATA_ATTRIBUTES:
+                self._user_defined_attributes.append(key)
+            setattr(self, key, value)
+
+    def remove_attr(self, attributes):
+        """Removes user-defined attributes from the class instance in use.
+           If a user specifies a required attribute to be deleted, sets
+           attr to None.
+
+        Args:
+            attributes: A list of user-defined attributes for deletion.
+        """
+        _required_attr = SPECIFIED_METADATA_ATTRIBUTES
+        _required_rem = []
+        _no_attr = []
+        for attr in attributes:
+            if attr in _required_attr:
+                setattr(self, attr, None)
+            elif hasattr(self, attr):
+                delattr(self, attr)
+            else:
+                _no_attr.append(attr)
+        if _required_rem:
+            raise ValueError(f'{", ".join(_required_rem)} are required and '
+                             f'cannot be removed.')
+        if _no_attr:
+            raise ValueError(f'{", ".join(_no_attr)} are not attributes of '
+                             f'this instance.')
+
+
     @property
     def point_name(self):
         """Returns fov_name instead of deprecated point_name."""

--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -213,7 +213,7 @@ class MibiImage():
             setattr(self, key, value)
 
 
-    def remove_attr(self, *args):
+    def remove_attr(self, attributes):
         """Removes user-defined attributes from the class instance in use.
 
         Args:
@@ -226,9 +226,11 @@ class MibiImage():
                 * attempts to remove a required attribute.
                 * an attribute is not defined for this instance.
         """
-        required_rem = [attr for attr in args if attr
+        if isinstance(attributes, str):
+            attributes = list(attributes)
+        required_rem = [attr for attr in attributes if attr
                         in SPECIFIED_METADATA_ATTRIBUTES]
-        no_attr = [attr for attr in args if not hasattr(self, attr)]
+        no_attr = [attr for attr in attributes if not hasattr(self, attr)]
         if required_rem:
             if len(required_rem) == 1:
                 required_error = (f'{required_rem[0]} is a required '
@@ -245,7 +247,7 @@ class MibiImage():
                 required_error = (f'{", ".join(no_attr)} are not attributes '
                                   f'of this instance.')
             raise ValueError(required_error)
-        for attr in args:
+        for attr in attributes:
             delattr(self, attr)
             self._user_defined_attributes.remove(attr)
 

--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -227,7 +227,7 @@ class MibiImage():
                 * an attribute is not defined for this instance.
         """
         if isinstance(attributes, str):
-            attributes = list(attributes)
+            attributes = [attributes]
         required_rem = [attr for attr in attributes if attr
                         in SPECIFIED_METADATA_ATTRIBUTES]
         no_attr = [attr for attr in attributes if not hasattr(self, attr)]

--- a/mibidata/tests/test_mibi_image.py
+++ b/mibidata/tests/test_mibi_image.py
@@ -236,19 +236,19 @@ class TestMibiImage(unittest.TestCase):
     def test_remove_user_defined_metadata(self):
         image = mi.MibiImage(TEST_DATA, TUPLE_LABELS, **METADATA,
                              **USER_DEFINED_METADATA)
-        image.remove_attr(USER_DEFINED_METADATA.keys())
+        image.remove_attr(*list(USER_DEFINED_METADATA.keys()))
         expected = mi.MibiImage(TEST_DATA, TUPLE_LABELS, **METADATA)
         self.assertEqual(expected, image)
 
     def test_remove_required_metadata(self):
         image = mi.MibiImage(TEST_DATA, TUPLE_LABELS, **METADATA)
         with self.assertRaises(ValueError):
-            image.remove_attr(['fov_id'])
+            image.remove_attr('fov_id')
 
     def test_remove_undefined_user_metadata(self):
         image = mi.MibiImage(TEST_DATA, TUPLE_LABELS, **METADATA)
         with self.assertRaises(ValueError):
-            image.remove_attr(['x_size'])
+            image.remove_attr(*['x_size'])
 
     def test_metadata_wrong_fov_id(self):
         metadata = METADATA.copy()

--- a/mibidata/tests/test_mibi_image.py
+++ b/mibidata/tests/test_mibi_image.py
@@ -219,6 +219,37 @@ class TestMibiImage(unittest.TestCase):
         self.assertEqual(image._user_defined_attributes,
                          list(USER_DEFINED_METADATA))
 
+    def test_add_user_defined_metadata(self):
+        image = mi.MibiImage(TEST_DATA, TUPLE_LABELS, **METADATA)
+        image.add_attr(**USER_DEFINED_METADATA)
+        self.assertEqual(image._user_defined_attributes,
+                         list(USER_DEFINED_METADATA))
+
+    def test_add_existing_metadata(self):
+        image = mi.MibiImage(TEST_DATA, TUPLE_LABELS, **METADATA,
+                             **USER_DEFINED_METADATA)
+        metadata = METADATA.copy()
+        metadata = {**metadata, **USER_DEFINED_METADATA}
+        with self.assertRaises(ValueError):
+            image.add_attr(**metadata)
+
+    def test_remove_user_defined_metadata(self):
+        image = mi.MibiImage(TEST_DATA, TUPLE_LABELS, **METADATA,
+                             **USER_DEFINED_METADATA)
+        image.remove_attr(USER_DEFINED_METADATA.keys())
+        expected = mi.MibiImage(TEST_DATA, TUPLE_LABELS, **METADATA)
+        self.assertEqual(expected, image)
+
+    def test_remove_required_metadata(self):
+        image = mi.MibiImage(TEST_DATA, TUPLE_LABELS, **METADATA)
+        with self.assertRaises(ValueError):
+            image.remove_attr(['fov_id'])
+
+    def test_remove_undefined_user_metadata(self):
+        image = mi.MibiImage(TEST_DATA, TUPLE_LABELS, **METADATA)
+        with self.assertRaises(ValueError):
+            image.remove_attr(['x_size'])
+
     def test_metadata_wrong_fov_id(self):
         metadata = METADATA.copy()
         metadata = {**metadata, **USER_DEFINED_METADATA}

--- a/mibidata/tests/test_mibi_image.py
+++ b/mibidata/tests/test_mibi_image.py
@@ -236,7 +236,7 @@ class TestMibiImage(unittest.TestCase):
     def test_remove_user_defined_metadata(self):
         image = mi.MibiImage(TEST_DATA, TUPLE_LABELS, **METADATA,
                              **USER_DEFINED_METADATA)
-        image.remove_attr(*list(USER_DEFINED_METADATA.keys()))
+        image.remove_attr(USER_DEFINED_METADATA.keys())
         expected = mi.MibiImage(TEST_DATA, TUPLE_LABELS, **METADATA)
         self.assertEqual(expected, image)
 
@@ -248,7 +248,7 @@ class TestMibiImage(unittest.TestCase):
     def test_remove_undefined_user_metadata(self):
         image = mi.MibiImage(TEST_DATA, TUPLE_LABELS, **METADATA)
         with self.assertRaises(ValueError):
-            image.remove_attr(*['x_size'])
+            image.remove_attr(['x_size', 'y_size'])
 
     def test_metadata_wrong_fov_id(self):
         metadata = METADATA.copy()

--- a/mibidata/tests/test_mibi_image.py
+++ b/mibidata/tests/test_mibi_image.py
@@ -240,6 +240,13 @@ class TestMibiImage(unittest.TestCase):
         expected = mi.MibiImage(TEST_DATA, TUPLE_LABELS, **METADATA)
         self.assertEqual(expected, image)
 
+    def test_remove_single_user_defined_metadata(self):
+        image = mi.MibiImage(TEST_DATA, TUPLE_LABELS, **METADATA,
+                             x_size=500.)
+        image.remove_attr('x_size')
+        expected = mi.MibiImage(TEST_DATA, TUPLE_LABELS, **METADATA)
+        self.assertEqual(expected, image)
+
     def test_remove_required_metadata(self):
         image = mi.MibiImage(TEST_DATA, TUPLE_LABELS, **METADATA)
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Added add_attr(kwargs) and remove_attr(attributes) to MibiImage class.
add_attr():
- if user tries to add an attribute that already exists, will just update the value of attr
- allows user to specify user-defined and required attributes
- able to parse the format of data attribute accordingly
- if user defined, adds to _user_defined_attributes list

remove_attr():
- if user tries to remove required attribute, just sets it to None, otherwise removes attribute from instance and _user_defined_attributes list
- if user tries to remove attribute that does exists, just moves on
- warns user that they tried to delete required attributes
- warns user that tried to remove nonexistent attributes

Let me know if all of this functionality is ok.