### PR TITLE
Fix point retrieval in create_mibitiffs.

### DIFF
--- a/mibidata/combine_tiffs.py
+++ b/mibidata/combine_tiffs.py
@@ -94,7 +94,7 @@ def create_mibitiffs(input_folder, run_path, point, panel_path, slide, size,
     fovs, calibration = runs.parse_xml(run_path)
     point_number = int(point[5:])
     try:
-        fov = fovs[point_number]
+        fov = fovs[point_number - 1] # point number is 1-based, not 0-based
     except IndexError:
         raise IndexError('{} not found in run xml.'.format(point))
     if fov['date']:


### PR DESCRIPTION
The point name is defined 1-based, starting with 'Point1', but indices in python are 0-based. This bug caused the retrieval of the wrong point metadata from the run XML file, i.e. from Point2 instead of Point1.