### PR TITLE
TKR-688 Include run_id when requesting signed url for uploading tiff

### DIFF
--- a/mibitracker/request_helpers.py
+++ b/mibitracker/request_helpers.py
@@ -424,7 +424,8 @@ class MibiRequests():
         if run_id is None:
             raise ValueError(
                 'run_id is mandatory in MIBitracker >=v1.1 and cannot be None')
-        response = self.get('/upload_mibitiff/sign_tiff_url/').json()
+        response = self.get(
+            f'/upload_mibitiff/sign_tiff_url/?run_id={run_id}').json()
         try:
             with open(tiff_file, 'rb') as fh:
                 self._upload_mibitiff(response['url'], fh)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 setup(name='mibitracker-client',
       author='IONpath, Inc.',
       author_email='mibitracker-support@ionpath.com',
-      version='1.2.7',
+      version='1.2.8',
       url='https://github.com/ionpath/mibitracker-client',
       description='Python utilities for IONpath MIBItracker and MIBItiff data',
       license='GNU General Public License v3.0',


### PR DESCRIPTION
An upcoming release of MIBItracker will require the run id to be specified when initiating a tiff upload. Adding this parameter now allows it to continue to work with the current release (V1.2.0) and then still work once this is enforced in a later version.